### PR TITLE
fix: handle missing image column in landesregierungen tables

### DIFF
--- a/src/landesregierungen.res
+++ b/src/landesregierungen.res
@@ -184,6 +184,20 @@ let extractPoliticians = (
     switch (ministerName, party, imageUrl) {
     | (Some(ministerName), Some(party), Some(imageUrl)) =>
       createPoliticianAndAddToList(amt, ministerName, party, imageUrl, result)
+    | (Some(ministerName), Some(party), None) => {
+        // Some Wikipedia tables lack a photo column entirely.
+        // Use a placeholder so the pipeline doesn't crash.
+        let placeholderCell: tableCell = {
+          colStart: 0,
+          colEnd: 0,
+          rowStart: 0,
+          rowEnd: 0,
+          imageUrl: Some("https://upload.wikimedia.org/wikipedia/commons/thumb/8/89/Portrait_placeholder.svg/400px-Portrait_placeholder.svg.png"),
+          header: "placeholder",
+          linesOfText: [],
+        }
+        createPoliticianAndAddToList(amt, ministerName, party, placeholderCell, result)
+      }
     | _ => _panicOnMissingDetails(amt, ministerName, party, imageUrl, bundesland)
     }
   })

--- a/src/landesregierungen.spec.js
+++ b/src/landesregierungen.spec.js
@@ -1,0 +1,102 @@
+// landesregierungen.spec.js
+// Unit tests for the landesregierungen module.
+
+import { extractPoliticians } from "../src/landesregierungen.res.mjs";
+
+describe("extractPoliticians", () => {
+  const makeCell = (overrides) => ({
+    colStart: 0,
+    colEnd: 0,
+    rowStart: 0,
+    rowEnd: 0,
+    imageUrl: undefined,
+    header: "Amt",
+    linesOfText: ["Placeholder"],
+    ...overrides,
+  });
+
+  test("uses placeholder when image column is missing entirely", () => {
+    // Simulates Brandenburg's Kabinett Woidke V where some rows
+    // have no "Foto"/"Bild" column at all.
+    const amt = makeCell({
+      header: "Amt",
+      linesOfText: ["Minister der Finanzen"],
+      rowStart: 3,
+      rowEnd: 3,
+    });
+    const name = makeCell({
+      header: "Name",
+      linesOfText: ["Daniel Keller"],
+      colStart: 2,
+      colEnd: 2,
+      rowStart: 3,
+      rowEnd: 3,
+    });
+    const party = makeCell({
+      header: "Partei",
+      linesOfText: ["SPD"],
+      colStart: 4,
+      colEnd: 4,
+      rowStart: 3,
+      rowEnd: 3,
+    });
+
+    const cells = [amt, name, party]; // no image cell
+
+    const result = extractPoliticians(
+      [amt],
+      cells,
+      { state: "Brandenburg", urlCabinet: "https://de.wikipedia.org/wiki/Kabinett_Woidke_V" }
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Daniel Keller");
+    expect(result[0].party).toBe("SPD");
+    expect(result[0].imageUrl).toMatch(/Portrait_placeholder/);
+  });
+
+  test("still uses real image when image column is present", () => {
+    const amt = makeCell({
+      header: "Amt",
+      linesOfText: ["Ministerpräsident"],
+      rowStart: 0,
+      rowEnd: 0,
+    });
+    const name = makeCell({
+      header: "Name",
+      linesOfText: ["Dietmar Woidke"],
+      colStart: 2,
+      colEnd: 2,
+      rowStart: 0,
+      rowEnd: 0,
+    });
+    const party = makeCell({
+      header: "Partei",
+      linesOfText: ["SPD"],
+      colStart: 4,
+      colEnd: 4,
+      rowStart: 0,
+      rowEnd: 0,
+    });
+    const image = makeCell({
+      header: "Foto",
+      linesOfText: [],
+      imageUrl: "https://upload.wikimedia.org/wikipedia/commons/real-image.jpg",
+      colStart: 1,
+      colEnd: 1,
+      rowStart: 0,
+      rowEnd: 0,
+    });
+
+    const cells = [amt, name, party, image];
+
+    const result = extractPoliticians(
+      [amt],
+      cells,
+      { state: "Brandenburg", urlCabinet: "https://de.wikipedia.org/wiki/Kabinett_Woidke_V" }
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].imageUrl).toBe("https://upload.wikimedia.org/wikipedia/commons/real-image.jpg");
+  });
+});


### PR DESCRIPTION
Some Wikipedia cabinet tables (e.g. Kabinett Woidke V) lack a Foto/Bild column for certain ministers. Instead of crashing with 'Could not extract table info', we now use a placeholder image URL.

**Changes:**
- New switch branch in `extractPoliticians` for `(Some(name), Some(party), None)`
- Unit tests for both missing and present image cases

**Root cause:** Brandenburg's cabinet page has no photo for Daniel Keller (Minister der Finanzen), causing the pipeline to panic.

41/41 tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved politician data extraction to gracefully handle missing profile images by automatically using a default placeholder image instead of causing the entire extraction to fail.

* **Tests**
  * Added comprehensive unit tests for data extraction functionality, covering scenarios with and without available profile images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->