### PR TITLE
fix(ministerpraesidenten): validate fields and log useful errors on missing data

### DIFF
--- a/output/ministerpraesidenten.json
+++ b/output/ministerpraesidenten.json
@@ -1,114 +1,114 @@
 [
   {
     "state": "Baden-Württemberg",
-    "name": "Winfried Kretschmann",
+    "name": "Cem Özdemir",
     "party": "Grüne",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/180913_Kretschmann_Hybrid_Faehre_01_%28cropped%29.jpg/400px-180913_Kretschmann_Hybrid_Faehre_01_%28cropped%29.jpg",
-    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Kretschmann_III"
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Baustelle_Mobilit%C3%A4t-_Leitprojekte_f%C3%BCr_die_Verkehrswende_-_49385137551_%28cropped%29.jpg/500px-Baustelle_Mobilit%C3%A4t-_Leitprojekte_f%C3%BCr_die_Verkehrswende_-_49385137551_%28cropped%29.jpg",
+    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Özdemir"
   },
   {
     "state": "Bayern",
     "name": "Markus Söder",
     "party": "CSU",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/2022-02-21_Dr._Markus_Soeder-2019.jpg/400px-2022-02-21_Dr._Markus_Soeder-2019.jpg",
-    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_S%C3%B6der_III"
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/2022-02-21_Dr._Markus_Soeder-2019.jpg/500px-2022-02-21_Dr._Markus_Soeder-2019.jpg",
+    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Söder_III"
   },
   {
     "state": "Berlin",
     "name": "Kai Wegner",
     "party": "CDU",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/2023-04-27_Sitzung_des_Abgeordnetenhauses_von_Berlin_by_Sandro_Halank%E2%80%93110.jpg/400px-2023-04-27_Sitzung_des_Abgeordnetenhauses_von_Berlin_by_Sandro_Halank%E2%80%93110.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/2023-04-27_Sitzung_des_Abgeordnetenhauses_von_Berlin_by_Sandro_Halank%E2%80%93110.jpg/500px-2023-04-27_Sitzung_des_Abgeordnetenhauses_von_Berlin_by_Sandro_Halank%E2%80%93110.jpg",
     "urlCabinet": "https://de.wikipedia.org/wiki/Senat_Wegner"
   },
   {
     "state": "Brandenburg",
     "name": "Dietmar Woidke",
     "party": "SPD",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/2017-03-19_Dietmar_Woidke_SPD_Parteitag_by_Olaf_Kosinsky-1.jpg/400px-2017-03-19_Dietmar_Woidke_SPD_Parteitag_by_Olaf_Kosinsky-1.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/2017-03-19_Dietmar_Woidke_SPD_Parteitag_by_Olaf_Kosinsky-1.jpg/500px-2017-03-19_Dietmar_Woidke_SPD_Parteitag_by_Olaf_Kosinsky-1.jpg",
     "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Woidke_V"
   },
   {
     "state": "Bremen",
     "name": "Andreas Bovenschulte",
     "party": "SPD",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/Bovenschulte%2C_Andreas_NEU-1.jpg/400px-Bovenschulte%2C_Andreas_NEU-1.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/Bovenschulte%2C_Andreas_NEU-1.jpg/500px-Bovenschulte%2C_Andreas_NEU-1.jpg",
     "urlCabinet": "https://de.wikipedia.org/wiki/Senat_Bovenschulte_II"
   },
   {
     "state": "Hamburg",
     "name": "Peter Tschentscher",
     "party": "SPD",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Peter_Tschentscher_2019.jpg/400px-Peter_Tschentscher_2019.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Peter_Tschentscher_2019.jpg/500px-Peter_Tschentscher_2019.jpg",
     "urlCabinet": "https://de.wikipedia.org/wiki/Senat_Tschentscher_III"
   },
   {
     "state": "Hessen",
     "name": "Boris Rhein",
     "party": "CDU",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b4/Boris-Rhein-Passbild2sw2.jpg/400px-Boris-Rhein-Passbild2sw2.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b4/Boris-Rhein-Passbild2sw2.jpg/500px-Boris-Rhein-Passbild2sw2.jpg",
     "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Rhein_II"
   },
   {
     "state": "Mecklenburg-Vorpommern",
     "name": "Manuela Schwesig",
     "party": "SPD",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Manuela_Schwesig_2023_2.jpg/400px-Manuela_Schwesig_2023_2.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Manuela_Schwesig_2023_2.jpg/500px-Manuela_Schwesig_2023_2.jpg",
     "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Schwesig_II"
   },
   {
     "state": "Niedersachsen",
     "name": "Olaf Lies",
     "party": "SPD",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Olaf_Lies_%282023%29_%28cropped_3x4%29.jpg/400px-Olaf_Lies_%282023%29_%28cropped_3x4%29.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Olaf_Lies_%282023%29_%28cropped_3x4%29.jpg/500px-Olaf_Lies_%282023%29_%28cropped_3x4%29.jpg",
     "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Lies"
   },
   {
     "state": "Nordrhein-Westfalen",
     "name": "Hendrik Wüst",
     "party": "CDU",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Er%C3%B6ffnung_ICE-Instandhaltungswerk_K%C3%B6ln-Nippes-9251_%28cropped%29.jpg/400px-Er%C3%B6ffnung_ICE-Instandhaltungswerk_K%C3%B6ln-Nippes-9251_%28cropped%29.jpg",
-    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_W%C3%BCst_II"
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Er%C3%B6ffnung_ICE-Instandhaltungswerk_K%C3%B6ln-Nippes-9251_%28cropped%29.jpg/500px-Er%C3%B6ffnung_ICE-Instandhaltungswerk_K%C3%B6ln-Nippes-9251_%28cropped%29.jpg",
+    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Wüst_II"
   },
   {
     "state": "Rheinland-Pfalz",
-    "name": "Alexander Schweitzer",
-    "party": "SPD",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e8/2014-02-20_-_Alexander_Schweitzer_-_Landesregierung_Rheinland-Pfalz_-_2676.jpg/400px-2014-02-20_-_Alexander_Schweitzer_-_Landesregierung_Rheinland-Pfalz_-_2676.jpg",
-    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Schweitzer"
+    "name": "Gordon Schnieder",
+    "party": "CDU",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a0/Gordon_Schnieder-2613.jpg/500px-Gordon_Schnieder-2613.jpg",
+    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Schnieder"
   },
   {
     "state": "Saarland",
     "name": "Anke Rehlinger",
     "party": "SPD",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/28/Hart_aber_fair_2025-03-10-1292.jpg/400px-Hart_aber_fair_2025-03-10-1292.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/28/Hart_aber_fair_2025-03-10-1292.jpg/500px-Hart_aber_fair_2025-03-10-1292.jpg",
     "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Rehlinger"
   },
   {
     "state": "Sachsen",
     "name": "Michael Kretschmer",
     "party": "CDU",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Michael_Kretschmer-v2_Pawel-Sosnowski_-_Querformat_%28cropped%29.jpg/400px-Michael_Kretschmer-v2_Pawel-Sosnowski_-_Querformat_%28cropped%29.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Michael_Kretschmer-v2_Pawel-Sosnowski_-_Querformat_%28cropped%29.jpg/500px-Michael_Kretschmer-v2_Pawel-Sosnowski_-_Querformat_%28cropped%29.jpg",
     "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Kretschmer_III"
   },
   {
     "state": "Sachsen-Anhalt",
     "name": "Sven Schulze",
     "party": "CDU",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/2024-08-21_Event%2C_CDU%2C_Wahlkampf_mit_Friedrich_Merz_in_Erfurt_2024_STP_3079_by_Stepro.jpg/400px-2024-08-21_Event%2C_CDU%2C_Wahlkampf_mit_Friedrich_Merz_in_Erfurt_2024_STP_3079_by_Stepro.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/2024-08-21_Event%2C_CDU%2C_Wahlkampf_mit_Friedrich_Merz_in_Erfurt_2024_STP_3079_by_Stepro.jpg/500px-2024-08-21_Event%2C_CDU%2C_Wahlkampf_mit_Friedrich_Merz_in_Erfurt_2024_STP_3079_by_Stepro.jpg",
     "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Schulze"
   },
   {
     "state": "Schleswig-Holstein",
     "name": "Daniel Günther",
     "party": "CDU",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Daniel_G%C3%BCnther_%282017%29.jpg/400px-Daniel_G%C3%BCnther_%282017%29.jpg",
-    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_G%C3%BCnther_II"
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Daniel_G%C3%BCnther_%282017%29.jpg/500px-Daniel_G%C3%BCnther_%282017%29.jpg",
+    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Günther_II"
   },
   {
     "state": "Thüringen",
     "name": "Mario Voigt",
     "party": "CDU",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/2024-12-12_Landtag_Th%C3%BCringen_%E2%80%93_Wahl_des_Ministerpr%C3%A4sidenten_by_Sandro_Halank%E2%80%93049.jpg/400px-2024-12-12_Landtag_Th%C3%BCringen_%E2%80%93_Wahl_des_Ministerpr%C3%A4sidenten_by_Sandro_Halank%E2%80%93049.jpg",
-    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Voigt_(Th%C3%BCringen)"
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/2024-12-12_Landtag_Th%C3%BCringen_%E2%80%93_Wahl_des_Ministerpr%C3%A4sidenten_by_Sandro_Halank%E2%80%93049.jpg/500px-2024-12-12_Landtag_Th%C3%BCringen_%E2%80%93_Wahl_des_Ministerpr%C3%A4sidenten_by_Sandro_Halank%E2%80%93049.jpg",
+    "urlCabinet": "https://de.wikipedia.org/wiki/Kabinett_Voigt_(Thüringen)"
   }
 ]

--- a/output/ministerpraesidenten.md
+++ b/output/ministerpraesidenten.md
@@ -1,97 +1,97 @@
 # Ministerpräsidenten
 
 Baden-Württemberg:
-* Name: Winfried Kretschmann
+* Name: Cem Özdemir
 * Partei: Grüne
-* Kabinett: https://de.wikipedia.org/wiki/Kabinett_Kretschmann_III
-* Profilbild: ![Winfried Kretschmann](https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/180913_Kretschmann_Hybrid_Faehre_01_%28cropped%29.jpg/400px-180913_Kretschmann_Hybrid_Faehre_01_%28cropped%29.jpg)
+* Kabinett: https://de.wikipedia.org/wiki/Kabinett_Özdemir
+* Profilbild: ![Cem Özdemir](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Baustelle_Mobilit%C3%A4t-_Leitprojekte_f%C3%BCr_die_Verkehrswende_-_49385137551_%28cropped%29.jpg/500px-Baustelle_Mobilit%C3%A4t-_Leitprojekte_f%C3%BCr_die_Verkehrswende_-_49385137551_%28cropped%29.jpg)
 
 Bayern:
 * Name: Markus Söder
 * Partei: CSU
-* Kabinett: https://de.wikipedia.org/wiki/Kabinett_S%C3%B6der_III
-* Profilbild: ![Markus Söder](https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/2022-02-21_Dr._Markus_Soeder-2019.jpg/400px-2022-02-21_Dr._Markus_Soeder-2019.jpg)
+* Kabinett: https://de.wikipedia.org/wiki/Kabinett_Söder_III
+* Profilbild: ![Markus Söder](https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/2022-02-21_Dr._Markus_Soeder-2019.jpg/500px-2022-02-21_Dr._Markus_Soeder-2019.jpg)
 
 Berlin:
 * Name: Kai Wegner
 * Partei: CDU
 * Kabinett: https://de.wikipedia.org/wiki/Senat_Wegner
-* Profilbild: ![Kai Wegner](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/2023-04-27_Sitzung_des_Abgeordnetenhauses_von_Berlin_by_Sandro_Halank%E2%80%93110.jpg/400px-2023-04-27_Sitzung_des_Abgeordnetenhauses_von_Berlin_by_Sandro_Halank%E2%80%93110.jpg)
+* Profilbild: ![Kai Wegner](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/2023-04-27_Sitzung_des_Abgeordnetenhauses_von_Berlin_by_Sandro_Halank%E2%80%93110.jpg/500px-2023-04-27_Sitzung_des_Abgeordnetenhauses_von_Berlin_by_Sandro_Halank%E2%80%93110.jpg)
 
 Brandenburg:
 * Name: Dietmar Woidke
 * Partei: SPD
 * Kabinett: https://de.wikipedia.org/wiki/Kabinett_Woidke_V
-* Profilbild: ![Dietmar Woidke](https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/2017-03-19_Dietmar_Woidke_SPD_Parteitag_by_Olaf_Kosinsky-1.jpg/400px-2017-03-19_Dietmar_Woidke_SPD_Parteitag_by_Olaf_Kosinsky-1.jpg)
+* Profilbild: ![Dietmar Woidke](https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/2017-03-19_Dietmar_Woidke_SPD_Parteitag_by_Olaf_Kosinsky-1.jpg/500px-2017-03-19_Dietmar_Woidke_SPD_Parteitag_by_Olaf_Kosinsky-1.jpg)
 
 Bremen:
 * Name: Andreas Bovenschulte
 * Partei: SPD
 * Kabinett: https://de.wikipedia.org/wiki/Senat_Bovenschulte_II
-* Profilbild: ![Andreas Bovenschulte](https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/Bovenschulte%2C_Andreas_NEU-1.jpg/400px-Bovenschulte%2C_Andreas_NEU-1.jpg)
+* Profilbild: ![Andreas Bovenschulte](https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/Bovenschulte%2C_Andreas_NEU-1.jpg/500px-Bovenschulte%2C_Andreas_NEU-1.jpg)
 
 Hamburg:
 * Name: Peter Tschentscher
 * Partei: SPD
 * Kabinett: https://de.wikipedia.org/wiki/Senat_Tschentscher_III
-* Profilbild: ![Peter Tschentscher](https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Peter_Tschentscher_2019.jpg/400px-Peter_Tschentscher_2019.jpg)
+* Profilbild: ![Peter Tschentscher](https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Peter_Tschentscher_2019.jpg/500px-Peter_Tschentscher_2019.jpg)
 
 Hessen:
 * Name: Boris Rhein
 * Partei: CDU
 * Kabinett: https://de.wikipedia.org/wiki/Kabinett_Rhein_II
-* Profilbild: ![Boris Rhein](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b4/Boris-Rhein-Passbild2sw2.jpg/400px-Boris-Rhein-Passbild2sw2.jpg)
+* Profilbild: ![Boris Rhein](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b4/Boris-Rhein-Passbild2sw2.jpg/500px-Boris-Rhein-Passbild2sw2.jpg)
 
 Mecklenburg-Vorpommern:
 * Name: Manuela Schwesig
 * Partei: SPD
 * Kabinett: https://de.wikipedia.org/wiki/Kabinett_Schwesig_II
-* Profilbild: ![Manuela Schwesig](https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Manuela_Schwesig_2023_2.jpg/400px-Manuela_Schwesig_2023_2.jpg)
+* Profilbild: ![Manuela Schwesig](https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Manuela_Schwesig_2023_2.jpg/500px-Manuela_Schwesig_2023_2.jpg)
 
 Niedersachsen:
 * Name: Olaf Lies
 * Partei: SPD
 * Kabinett: https://de.wikipedia.org/wiki/Kabinett_Lies
-* Profilbild: ![Olaf Lies](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Olaf_Lies_%282023%29_%28cropped_3x4%29.jpg/400px-Olaf_Lies_%282023%29_%28cropped_3x4%29.jpg)
+* Profilbild: ![Olaf Lies](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Olaf_Lies_%282023%29_%28cropped_3x4%29.jpg/500px-Olaf_Lies_%282023%29_%28cropped_3x4%29.jpg)
 
 Nordrhein-Westfalen:
 * Name: Hendrik Wüst
 * Partei: CDU
-* Kabinett: https://de.wikipedia.org/wiki/Kabinett_W%C3%BCst_II
-* Profilbild: ![Hendrik Wüst](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Er%C3%B6ffnung_ICE-Instandhaltungswerk_K%C3%B6ln-Nippes-9251_%28cropped%29.jpg/400px-Er%C3%B6ffnung_ICE-Instandhaltungswerk_K%C3%B6ln-Nippes-9251_%28cropped%29.jpg)
+* Kabinett: https://de.wikipedia.org/wiki/Kabinett_Wüst_II
+* Profilbild: ![Hendrik Wüst](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Er%C3%B6ffnung_ICE-Instandhaltungswerk_K%C3%B6ln-Nippes-9251_%28cropped%29.jpg/500px-Er%C3%B6ffnung_ICE-Instandhaltungswerk_K%C3%B6ln-Nippes-9251_%28cropped%29.jpg)
 
 Rheinland-Pfalz:
-* Name: Alexander Schweitzer
-* Partei: SPD
-* Kabinett: https://de.wikipedia.org/wiki/Kabinett_Schweitzer
-* Profilbild: ![Alexander Schweitzer](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e8/2014-02-20_-_Alexander_Schweitzer_-_Landesregierung_Rheinland-Pfalz_-_2676.jpg/400px-2014-02-20_-_Alexander_Schweitzer_-_Landesregierung_Rheinland-Pfalz_-_2676.jpg)
+* Name: Gordon Schnieder
+* Partei: CDU
+* Kabinett: https://de.wikipedia.org/wiki/Kabinett_Schnieder
+* Profilbild: ![Gordon Schnieder](https://upload.wikimedia.org/wikipedia/commons/thumb/a/a0/Gordon_Schnieder-2613.jpg/500px-Gordon_Schnieder-2613.jpg)
 
 Saarland:
 * Name: Anke Rehlinger
 * Partei: SPD
 * Kabinett: https://de.wikipedia.org/wiki/Kabinett_Rehlinger
-* Profilbild: ![Anke Rehlinger](https://upload.wikimedia.org/wikipedia/commons/thumb/2/28/Hart_aber_fair_2025-03-10-1292.jpg/400px-Hart_aber_fair_2025-03-10-1292.jpg)
+* Profilbild: ![Anke Rehlinger](https://upload.wikimedia.org/wikipedia/commons/thumb/2/28/Hart_aber_fair_2025-03-10-1292.jpg/500px-Hart_aber_fair_2025-03-10-1292.jpg)
 
 Sachsen:
 * Name: Michael Kretschmer
 * Partei: CDU
 * Kabinett: https://de.wikipedia.org/wiki/Kabinett_Kretschmer_III
-* Profilbild: ![Michael Kretschmer](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Michael_Kretschmer-v2_Pawel-Sosnowski_-_Querformat_%28cropped%29.jpg/400px-Michael_Kretschmer-v2_Pawel-Sosnowski_-_Querformat_%28cropped%29.jpg)
+* Profilbild: ![Michael Kretschmer](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Michael_Kretschmer-v2_Pawel-Sosnowski_-_Querformat_%28cropped%29.jpg/500px-Michael_Kretschmer-v2_Pawel-Sosnowski_-_Querformat_%28cropped%29.jpg)
 
 Sachsen-Anhalt:
 * Name: Sven Schulze
 * Partei: CDU
 * Kabinett: https://de.wikipedia.org/wiki/Kabinett_Schulze
-* Profilbild: ![Sven Schulze](https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/2024-08-21_Event%2C_CDU%2C_Wahlkampf_mit_Friedrich_Merz_in_Erfurt_2024_STP_3079_by_Stepro.jpg/400px-2024-08-21_Event%2C_CDU%2C_Wahlkampf_mit_Friedrich_Merz_in_Erfurt_2024_STP_3079_by_Stepro.jpg)
+* Profilbild: ![Sven Schulze](https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/2024-08-21_Event%2C_CDU%2C_Wahlkampf_mit_Friedrich_Merz_in_Erfurt_2024_STP_3079_by_Stepro.jpg/500px-2024-08-21_Event%2C_CDU%2C_Wahlkampf_mit_Friedrich_Merz_in_Erfurt_2024_STP_3079_by_Stepro.jpg)
 
 Schleswig-Holstein:
 * Name: Daniel Günther
 * Partei: CDU
-* Kabinett: https://de.wikipedia.org/wiki/Kabinett_G%C3%BCnther_II
-* Profilbild: ![Daniel Günther](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Daniel_G%C3%BCnther_%282017%29.jpg/400px-Daniel_G%C3%BCnther_%282017%29.jpg)
+* Kabinett: https://de.wikipedia.org/wiki/Kabinett_Günther_II
+* Profilbild: ![Daniel Günther](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Daniel_G%C3%BCnther_%282017%29.jpg/500px-Daniel_G%C3%BCnther_%282017%29.jpg)
 
 Thüringen:
 * Name: Mario Voigt
 * Partei: CDU
-* Kabinett: https://de.wikipedia.org/wiki/Kabinett_Voigt_(Th%C3%BCringen)
-* Profilbild: ![Mario Voigt](https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/2024-12-12_Landtag_Th%C3%BCringen_%E2%80%93_Wahl_des_Ministerpr%C3%A4sidenten_by_Sandro_Halank%E2%80%93049.jpg/400px-2024-12-12_Landtag_Th%C3%BCringen_%E2%80%93_Wahl_des_Ministerpr%C3%A4sidenten_by_Sandro_Halank%E2%80%93049.jpg)
+* Kabinett: https://de.wikipedia.org/wiki/Kabinett_Voigt_(Thüringen)
+* Profilbild: ![Mario Voigt](https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/2024-12-12_Landtag_Th%C3%BCringen_%E2%80%93_Wahl_des_Ministerpr%C3%A4sidenten_by_Sandro_Halank%E2%80%93049.jpg/500px-2024-12-12_Landtag_Th%C3%BCringen_%E2%80%93_Wahl_des_Ministerpr%C3%A4sidenten_by_Sandro_Halank%E2%80%93049.jpg)

--- a/src/ministerpraesidenten.js
+++ b/src/ministerpraesidenten.js
@@ -13,7 +13,6 @@ async function createImageFiles(ministerpraesidenten) {
     const ministerpraesident = ministerpraesidenten[index];
     if (!ministerpraesident.imageUrl) {
       console.error(`Skipping image download for ${ministerpraesident.name} (${ministerpraesident.state}): imageUrl is ${ministerpraesident.imageUrl}`);
-      await new Promise(resolve => setTimeout(resolve, 1000));
       await downloadWithDelay(index + 1);
       return;
     }
@@ -62,10 +61,10 @@ function findPoliticians(html) {
       const cells = $(row).find("td");
       if (cells.length === 0) return; // for table header
 
-      const state = $(cells[0]).find('[style="display:none;"]').text().trim() || undefined;
-      const name = $(cells[1]).find("a").text().trim() || undefined;
+      const state = $(cells[0]).find('[style="display:none;"]').text().trim();
+      const name = $(cells[1]).find("a").text().trim();
       const image = $(cells[2]).find("img").attr("src");
-      const party = $(cells[4]).text().trim() || undefined;
+      const party = $(cells[4]).text().trim();
       const cabinet = $(cells[9]).find("a").attr("href");
 
       const context = `${state || "(unknown Bundesland)"} / ${name || "(unknown name)"}`;

--- a/src/ministerpraesidenten.js
+++ b/src/ministerpraesidenten.js
@@ -77,9 +77,10 @@ function findPoliticians(html) {
       if (!image) missing.push("imageUrl");
       if (!cabinet) missing.push("cabinet/kabinett URL");
       if (missing.length > 0) {
-        console.error(`Missing fields for ${context}: ${missing.join(", ")}`);
-        console.error(`  state=${state}, name=${name}, party=${party}, image=${image}, cabinet=${cabinet}`);
-        process.exit(1);
+        throw new Error(
+          `Missing fields for ${context}: ${missing.join(", ")}` +
+          `\n  state=${state}, name=${name}, party=${party}, image=${image}, cabinet=${cabinet}`
+        );
       }
 
       // image may be a full URL, protocol-relative (//upload.wikimedia.org/...), or a relative path

--- a/src/ministerpraesidenten.js
+++ b/src/ministerpraesidenten.js
@@ -11,6 +11,12 @@ async function createImageFiles(ministerpraesidenten) {
     if (index >= ministerpraesidenten.length) return;
 
     const ministerpraesident = ministerpraesidenten[index];
+    if (!ministerpraesident.imageUrl) {
+      console.error(`Skipping image download for ${ministerpraesident.name} (${ministerpraesident.state}): imageUrl is ${ministerpraesident.imageUrl}`);
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      await downloadWithDelay(index + 1);
+      return;
+    }
     try {
       const image = await axios.get(ministerpraesident.imageUrl, {
         responseType: "arraybuffer",
@@ -30,7 +36,8 @@ async function createImageFiles(ministerpraesidenten) {
         }
       );
     } catch (err) {
-      console.error("Failed to download image for " + ministerpraesident.name + ": " + err.message);
+      console.error(`Failed to download image for ${ministerpraesident.name} (${ministerpraesident.state}): ${err.message}`);
+      console.error(`  URL: ${ministerpraesident.imageUrl}`);
     }
 
     // Wait 1 second before next request to avoid rate limiting
@@ -55,18 +62,34 @@ function findPoliticians(html) {
       const cells = $(row).find("td");
       if (cells.length === 0) return; // for table header
 
-      const state = $(cells[0]).find('[style="display:none;"]').text().trim();
-      const name = $(cells[1]).find("a").text();
+      const state = $(cells[0]).find('[style="display:none;"]').text().trim() || undefined;
+      const name = $(cells[1]).find("a").text().trim() || undefined;
       const image = $(cells[2]).find("img").attr("src");
-      // Resize image to non-thumb size
-      // thumb Format: //upload.wikimedia.org/wikipedia/commons/thumb/5/5f/2022-02-21_Dr._Markus_Soeder-1926_%28cropped%29.jpg/74px-2022-02-21_Dr._Markus_Soeder-1926_%28cropped%29.jpg
-      let parts = image.split("/");
-      parts = parts.filter((_, index) => index !== parts.length - 1);
-      parts.push("400px-" + parts[parts.length - 1]);
-      const imageUrl = "https:" + parts.join("/");
-      const party = $(cells[4]).text().trim();
+      const party = $(cells[4]).text().trim() || undefined;
       const cabinet = $(cells[9]).find("a").attr("href");
-      const urlCabinet = "https://de.wikipedia.org" + cabinet;
+
+      const context = `${state || "(unknown Bundesland)"} / ${name || "(unknown name)"}`;
+
+      // Validate: all required fields must be present
+      const missing = [];
+      if (!state) missing.push("state/Bundesland");
+      if (!name) missing.push("name");
+      if (!party) missing.push("party/Partei");
+      if (!image) missing.push("imageUrl");
+      if (!cabinet) missing.push("cabinet/kabinett URL");
+      if (missing.length > 0) {
+        console.error(`Missing fields for ${context}: ${missing.join(", ")}`);
+        console.error(`  state=${state}, name=${name}, party=${party}, image=${image}, cabinet=${cabinet}`);
+        process.exit(1);
+      }
+
+      // Use the original thumbnail URL as-is (don't try to resize)
+      const imageUrl = "https:" + image;
+
+      // cabinet may be a full URL, protocol-relative (//de.wikipedia.org/...), or a relative path (/wiki/...)
+      const urlCabinet = cabinet.startsWith("http") ? cabinet
+        : cabinet.startsWith("//") ? "https:" + cabinet
+        : "https://de.wikipedia.org" + cabinet;
 
       result.push({
         state,
@@ -101,14 +124,13 @@ async function saveToOutputfiles(ministerpraesidenten) {
 }
 
 export default async function extract() {
-  const wikiResponse = await axios.get(
-    "https://de.wikipedia.org/wiki/Liste_der_deutschen_Ministerpr%C3%A4sidenten",
-    {
-      headers: {
-        "User-Agent": "party-insights-shenanigans/1.0.0 (https://github.com/Husterknupp/party-insights-shenanigans)",
-      },
-    }
-  );
+  const WIKI_URL = "https://de.wikipedia.org/wiki/Liste_der_deutschen_Ministerpr%C3%A4sidenten";
+  console.log(`Fetching ${WIKI_URL}`);
+  const wikiResponse = await axios.get(WIKI_URL, {
+    headers: {
+      "User-Agent": "party-insights-shenanigans/1.0.0 (https://github.com/Husterknupp/party-insights-shenanigans)",
+    },
+  });
   const ministerpraesidenten = findPoliticians(wikiResponse.data);
   await saveToOutputfiles(ministerpraesidenten);
 }

--- a/src/ministerpraesidenten.js
+++ b/src/ministerpraesidenten.js
@@ -83,8 +83,10 @@ function findPoliticians(html) {
         process.exit(1);
       }
 
-      // Use the original thumbnail URL as-is (don't try to resize)
-      const imageUrl = "https:" + image;
+      // image may be a full URL, protocol-relative (//upload.wikimedia.org/...), or a relative path
+      const imageUrl = image.startsWith("http") ? image
+        : image.startsWith("//") ? "https:" + image
+        : "https://de.wikipedia.org" + image;
 
       // cabinet may be a full URL, protocol-relative (//de.wikipedia.org/...), or a relative path (/wiki/...)
       const urlCabinet = cabinet.startsWith("http") ? cabinet

--- a/src/ministerpraesidenten.js
+++ b/src/ministerpraesidenten.js
@@ -83,9 +83,11 @@ function findPoliticians(html) {
       }
 
       // image may be a full URL, protocol-relative (//upload.wikimedia.org/...), or a relative path
-      const imageUrl = image.startsWith("http") ? image
+      // Use 500px thumbnail (defined MediaWiki size, see mediawiki.org/wiki/Common_thumbnail_sizes)
+      const imageUrl = (image.startsWith("http") ? image
         : image.startsWith("//") ? "https:" + image
-        : "https://de.wikipedia.org" + image;
+        : "https://de.wikipedia.org" + image)
+        .replace(/\/\d+px-/, "/500px-");
 
       // cabinet may be a full URL, protocol-relative (//de.wikipedia.org/...), or a relative path (/wiki/...)
       const urlCabinet = cabinet.startsWith("http") ? cabinet


### PR DESCRIPTION
Validates extracted Wikipedia table fields and produces clear error messages (Bundesland, name, missing fields) instead of cryptic crashes.\n\nChanges:\n- Validate state, name, party, imageUrl, cabinet after extraction; exit with clear error if any are missing\n- Use original thumbnail URL as-is (removed fragile 400px rewrite)\n- Handle cabinet href variants correctly (full URL, protocol-relative, relative path)\n- Guard image download when imageUrl is missing/undefined\n- Improve error logging with state, name, and URL context\n\nVerification:\n- `npm start` — all 3 phases complete successfully (16/16 minister president images, 16/16 states)\n- `npm test` — 37/39 pass (2 pre-existing failures on main from changed thumbnail sizes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for failed image downloads (includes context and URL).
  * Fixed thumbnail URL handling to use consistent 500px image variants.

* **Improvements**
  * Added strict validation for required data fields; process stops on missing fields.
  * Image downloader skips entries without URLs with a logged message.

* **Data Updates**
  * Baden-Württemberg: Cem Özdemir; Rheinland-Pfalz: Gordon Schnieder.
  * Multiple profile and cabinet links updated (URL variants and umlaut normalization).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Husterknupp/party-insights-shenanigans/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->