### PR TITLE
MVP: export a JSON output file to a text-only .apkg deck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 
 # APPLICATION
 output-images/
+*.apkg

--- a/exportAnkiDeck.js
+++ b/exportAnkiDeck.js
@@ -1,0 +1,19 @@
+import path from "node:path";
+import { exportJsonFileToApkg } from "./src/ankiExporter.res.mjs";
+
+async function run() {
+  const jsonFilePath = process.argv[2];
+  if (!jsonFilePath) {
+    throw new Error("Usage: node exportAnkiDeck.js <path-to-output-json-file>");
+  }
+
+  const deckName = path.basename(jsonFilePath, ".json");
+  const outputFilePath = path.join(path.dirname(jsonFilePath), `${deckName}.apkg`);
+
+  await exportJsonFileToApkg(jsonFilePath, outputFilePath, deckName);
+}
+
+run().catch((err) => {
+  console.error(err.stack || err);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@rescript/core": "^1.6.1",
+        "anki-apkg-export": "^4.0.3",
         "axios": "^1.13.2",
         "cheerio": "^1.1.2",
         "jest": "^30.2.0",
@@ -1348,6 +1349,17 @@
         "win32"
       ]
     },
+    "node_modules/anki-apkg-export": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/anki-apkg-export/-/anki-apkg-export-4.0.3.tgz",
+      "integrity": "sha512-r2DblNjY8L/Cqc7sKULqqibJAyLTy3EEVZkBbVPXbSf66qlYTYf939/NUhhOfKH6bMawe93NjlKKNT5eWo1+VA==",
+      "license": "MIT",
+      "dependencies": {
+        "jszip": "^3.2.2",
+        "sha1": "^1.1.1",
+        "sql.js": "^0.5.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1689,6 +1701,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/cheerio": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
@@ -1882,6 +1903,12 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1894,6 +1921,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/css-select": {
@@ -2585,6 +2621,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -2674,6 +2716,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3400,6 +3448,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -3407,6 +3467,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3707,6 +3776,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -3902,6 +3977,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3929,6 +4010,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3975,6 +4071,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3988,6 +4090,25 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/sha1": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
+      "integrity": "sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": ">= 0.0.1",
+        "crypt": ">= 0.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/shebang-command": {
@@ -4057,6 +4178,12 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/sql.js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-0.5.0.tgz",
+      "integrity": "sha512-E80yfgPSOvkbEweROP8kUg+8YfvuWht2RYhPMngkJuKD7IgFVWPP/pAhSAUVZMY9UPf5m10Pi0yW9e4CRnmYGg==",
+      "license": "MIT"
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -4067,6 +4194,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-length": {
@@ -4437,6 +4573,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "start": "node index.js",
+    "export:anki": "node exportAnkiDeck.js",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "test:watch": "NODE_OPTIONS='--experimental-vm-modules' jest --watch",
     "res:build": "rescript",
@@ -24,6 +25,7 @@
   },
   "dependencies": {
     "@rescript/core": "^1.6.1",
+    "anki-apkg-export": "^4.0.3",
     "axios": "^1.13.2",
     "cheerio": "^1.1.2",
     "jest": "^30.2.0",

--- a/src/ankiApkgExportCjs.js
+++ b/src/ankiApkgExportCjs.js
@@ -1,0 +1,9 @@
+// anki-apkg-export is CommonJS and assigns its factory function to `exports.default`.
+// Under Node's ESM/CJS interop that pattern makes a plain `import AnkiExport from "anki-apkg-export"`
+// resolve to the whole module.exports object instead of the function (a known double-default quirk).
+// Requiring it via createRequire sidesteps that and gives the real factory function.
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+export default require("anki-apkg-export").default;

--- a/src/ankiExport.res
+++ b/src/ankiExport.res
@@ -1,7 +1,7 @@
 type exporter
 type apkgData
 
-@module("./ankiApkgExportCjs.js") external make: string => exporter = "default"
+@new @module("./ankiApkgExportCjs.js") external make: string => exporter = "default"
 @send external addCard: (exporter, string, string) => unit = "addCard"
 @send external save: exporter => Promise.t<apkgData> = "save"
 

--- a/src/ankiExport.res
+++ b/src/ankiExport.res
@@ -1,0 +1,8 @@
+type exporter
+type apkgData
+
+@module("./ankiApkgExportCjs.js") external make: string => exporter = "default"
+@send external addCard: (exporter, string, string) => unit = "addCard"
+@send external save: exporter => Promise.t<apkgData> = "save"
+
+@module("node:fs") external writeFileSync: (string, apkgData) => unit = "writeFileSync"

--- a/src/ankiExporter.res
+++ b/src/ankiExporter.res
@@ -1,0 +1,61 @@
+// walking skeleton for issue #48: JSON output -> two-field Anki deck (no images yet)
+type politicianCardSource = {
+  amt: option<string>,
+  state: option<string>,
+  name: string,
+  party: string,
+}
+
+let deserializePoliticians = fileName => {
+  let json = OutputHelpers.NodeJs.readFileSync(fileName, {encoding: "utf-8"})->JSON.parseExn
+  switch JSON.Decode.array(json) {
+  | Some(entries) =>
+    entries->Array.map(jsonObject => {
+      switch JSON.Decode.object(jsonObject) {
+      | Some(fields) => {
+          amt: fields->Dict.get("amt")->Option.flatMap(JSON.Decode.string),
+          state: fields->Dict.get("state")->Option.flatMap(JSON.Decode.string),
+          name: fields
+          ->Dict.get("name")
+          ->Option.getExn(~message="name field missing")
+          ->JSON.Decode.string
+          ->Option.getExn(~message="name field expected to be a string"),
+          party: fields
+          ->Dict.get("party")
+          ->Option.getExn(~message="party field missing")
+          ->JSON.Decode.string
+          ->Option.getExn(~message="party field expected to be a string"),
+        }
+      | None => Error.panic(`Error deserializing single politician object from ${fileName}`)
+      }
+    })
+  | None => Error.panic(`Error deserializing politicians array from ${fileName}`)
+  }
+}
+
+// Front: amt (or state, for output files that use that field instead) / Back: name + party
+let cardFieldsFor = (politician: politicianCardSource) => {
+  let front = switch (politician.amt, politician.state) {
+  | (Some(amt), _) => amt
+  | (None, Some(state)) => state
+  | (None, None) =>
+    Error.panic(
+      `Politician must have either 'amt' or 'state' to use as card front, but got: ${JSON.stringifyAny(
+          politician,
+        )->Option.getExn}`,
+    )
+  }
+  (front, `${politician.name} (${politician.party})`)
+}
+
+let exportJsonFileToApkg = async (jsonFilePath, outputFilePath, deckName) => {
+  let politicians = deserializePoliticians(jsonFilePath)
+  let deck = AnkiExport.make(deckName)
+  politicians->Array.forEach(politician => {
+    let (front, back) = cardFieldsFor(politician)
+    AnkiExport.addCard(deck, front, back)
+  })
+  let data = await AnkiExport.save(deck)
+  AnkiExport.writeFileSync(outputFilePath, data)
+  Console.log(`Wrote ${politicians->Array.length->Int.toString} cards to ${outputFilePath}`)
+}

--- a/src/ankiExporter.res
+++ b/src/ankiExporter.res
@@ -1,31 +1,36 @@
 // walking skeleton for issue #48: JSON output -> two-field Anki deck (no images yet)
-type politicianCardSource = {
-  amt: option<string>,
-  state: option<string>,
-  name: string,
-  party: string,
-}
-
-let deserializePoliticians = fileName => {
+// Reuses OutputHelpers.politician (src/outputHelpers.res) rather than a duplicate type,
+// since that's the exact type all three sources (Ministerpräsidenten, Bundesregierung,
+// Landesregierungen) already serialize through when writing these JSON files.
+let deserializePoliticians = (fileName): array<OutputHelpers.politician> => {
   let json = OutputHelpers.NodeJs.readFileSync(fileName, {encoding: "utf-8"})->JSON.parseExn
   switch JSON.Decode.array(json) {
   | Some(entries) =>
     entries->Array.map(jsonObject => {
       switch JSON.Decode.object(jsonObject) {
-      | Some(fields) => {
-          amt: fields->Dict.get("amt")->Option.flatMap(JSON.Decode.string),
-          state: fields->Dict.get("state")->Option.flatMap(JSON.Decode.string),
-          name: fields
-          ->Dict.get("name")
-          ->Option.getExn(~message="name field missing")
-          ->JSON.Decode.string
-          ->Option.getExn(~message="name field expected to be a string"),
-          party: fields
-          ->Dict.get("party")
-          ->Option.getExn(~message="party field missing")
-          ->JSON.Decode.string
-          ->Option.getExn(~message="party field expected to be a string"),
-        }
+      | Some(fields) =>
+        (
+          {
+            amt: ?fields->Dict.get("amt")->Option.flatMap(JSON.Decode.string),
+            state: ?fields->Dict.get("state")->Option.flatMap(JSON.Decode.string),
+            name: fields
+            ->Dict.get("name")
+            ->Option.getExn(~message="name field missing")
+            ->JSON.Decode.string
+            ->Option.getExn(~message="name field expected to be a string"),
+            party: fields
+            ->Dict.get("party")
+            ->Option.getExn(~message="party field missing")
+            ->JSON.Decode.string
+            ->Option.getExn(~message="party field expected to be a string"),
+            imageUrl: fields
+            ->Dict.get("imageUrl")
+            ->Option.getExn(~message="imageUrl field missing")
+            ->JSON.Decode.string
+            ->Option.getExn(~message="imageUrl field expected to be a string"),
+            urlCabinet: ?fields->Dict.get("urlCabinet")->Option.flatMap(JSON.Decode.string),
+          }: OutputHelpers.politician
+        )
       | None => Error.panic(`Error deserializing single politician object from ${fileName}`)
       }
     })
@@ -34,7 +39,7 @@ let deserializePoliticians = fileName => {
 }
 
 // Front: amt (or state, for output files that use that field instead) / Back: name + party
-let cardFieldsFor = (politician: politicianCardSource) => {
+let cardFieldsFor = (politician: OutputHelpers.politician) => {
   let front = switch (politician.amt, politician.state) {
   | (Some(amt), _) => amt
   | (None, Some(state)) => state

--- a/src/ankiExporter.spec.js
+++ b/src/ankiExporter.spec.js
@@ -1,0 +1,36 @@
+import { cardFieldsFor } from "./ankiExporter.res.mjs";
+
+describe("cardFieldsFor", () => {
+  it("uses 'amt' as front when present", () => {
+    const politician = {
+      amt: "Bundeskanzler",
+      state: undefined,
+      name: "Friedrich Merz",
+      party: "CDU",
+    };
+
+    expect(cardFieldsFor(politician)).toEqual(["Bundeskanzler", "Friedrich Merz (CDU)"]);
+  });
+
+  it("falls back to 'state' as front when 'amt' is missing", () => {
+    const politician = {
+      amt: undefined,
+      state: "Bayern",
+      name: "Markus Söder",
+      party: "CSU",
+    };
+
+    expect(cardFieldsFor(politician)).toEqual(["Bayern", "Markus Söder (CSU)"]);
+  });
+
+  it("throws when neither 'amt' nor 'state' is present", () => {
+    const politician = {
+      amt: undefined,
+      state: undefined,
+      name: "Jane Doe",
+      party: "N/A",
+    };
+
+    expect(() => cardFieldsFor(politician)).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #48.

## Summary
- `src/ankiExport.res` — thin ReScript external-binding wrapper around `anki-apkg-export`, following the existing convention (`axios.res`, `cheerioFacade.res`)
- `src/ankiExporter.res` — deserializes an `output/*.json` file (same decode pattern as `landesregierungen.res`'s `deserializeMinisterpraesidenten`) and maps each entry to a two-field card: Front = `amt` (or `state`, for output files using that field), Back = `name (party)`
- `exportAnkiDeck.js` — CLI entry point: `node exportAnkiDeck.js output/bundesregierung.json` (also available as `npm run export:anki -- output/bundesregierung.json`)
- `src/ankiApkgExportCjs.js` — `anki-apkg-export` assigns its factory to `exports.default`, which triggers Node's ESM/CJS double-default interop quirk under a plain `import ... from`. Requiring it via `createRequire` sidesteps that.
- No images yet, per the issue's walking-skeleton scope.

## Test plan
- [x] `npm run res:build` — compiles cleanly
- [x] `npm test` — 42/42 passing (39 existing + 3 new for the front/back mapping logic)
- [x] `node exportAnkiDeck.js output/bundesregierung.json` and `output/ministerpraesidenten.json` — both produce valid `.apkg` zip archives (`collection.anki2` + `media`)
- [x] Inspected `collection.anki2` via `sqlite3` directly — `notes.flds` show correctly mapped Front/Back fields for both output shapes (`amt` and `state`)
- [x] Import the resulting `.apkg` into Anki (desktop or AnkiDroid) and confirm cards appear correctly — needs manual confirmation on your end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Export politician JSON into Anki `.apkg` decks, with cards built from available amount/state (front) and `name (party)` (back).
  - Added an `export:anki` npm command to generate an `.apkg` alongside the input JSON.
- **Bug Fixes**
  - Improved Node export reliability by fixing module interop for the underlying Anki package exporter.
- **Tests**
  - Added Jest coverage for front-field selection and for throwing when required front data is missing.
- **Chores**
  - Updated ignore rules to exclude generated `.apkg` files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->