### PR TITLE
Add image support to the Anki export

### DIFF
--- a/src/ankiExport.res
+++ b/src/ankiExport.res
@@ -1,8 +1,11 @@
 type exporter
 type apkgData
+// binary payload for a media file; in practice the Buffer axios hands back from an image download
+type mediaData
 
 @new @module("./ankiApkgExportCjs.js") external make: string => exporter = "default"
 @send external addCard: (exporter, string, string) => unit = "addCard"
+@send external addMedia: (exporter, string, mediaData) => unit = "addMedia"
 @send external save: exporter => Promise.t<apkgData> = "save"
 
 @module("node:fs") external writeFileSync: (string, apkgData) => unit = "writeFileSync"

--- a/src/ankiExporter.images.spec.js
+++ b/src/ankiExporter.images.spec.js
@@ -75,14 +75,14 @@ describe("_downloadMediaFor", () => {
     expect(axiosGetMock).not.toHaveBeenCalled();
   });
 
-  it("skips (without throwing) when the download rejects", async () => {
+  it("throws when the download rejects", async () => {
     axiosGetMock.mockRejectedValue(new Error("404 Not Found"));
 
-    const result = await _downloadMediaFor(
-      { name: "Jane Doe", party: "N/A", imageUrl: "https://example.com/broken.png" },
-      0,
-    );
-
-    expect(result).toBeUndefined();
+    await expect(
+      _downloadMediaFor(
+        { name: "Jane Doe", party: "N/A", imageUrl: "https://example.com/broken.png" },
+        0,
+      ),
+    ).rejects.toThrow("404 Not Found");
   });
 });

--- a/src/ankiExporter.images.spec.js
+++ b/src/ankiExporter.images.spec.js
@@ -1,0 +1,80 @@
+import { jest } from "@jest/globals";
+
+// axios must be mocked before ankiExporter.res.mjs (which pulls in axios.res.mjs) is
+// ever imported anywhere in this file, so this stays a dedicated spec file rather than
+// living alongside the unmocked tests in ankiExporter.spec.js.
+const axiosGetMock = jest.fn();
+
+jest.unstable_mockModule("axios", () => ({
+  default: { get: axiosGetMock },
+}));
+
+const { _fileExtensionFor, _downloadMediaFor } = await import("./ankiExporter.res.mjs");
+
+describe("_fileExtensionFor", () => {
+  it("extracts a known extension from the URL path", () => {
+    expect(_fileExtensionFor("https://example.com/foo/bar.PNG")).toBe("png");
+  });
+
+  it("ignores query strings when detecting the extension", () => {
+    expect(_fileExtensionFor("https://example.com/foo/bar.jpg?width=500")).toBe("jpg");
+  });
+
+  it("falls back to jpg for an unrecognized extension", () => {
+    expect(_fileExtensionFor("https://example.com/foo/bar.tiff")).toBe("jpg");
+  });
+
+  it("falls back to jpg when there is no extension at all", () => {
+    expect(_fileExtensionFor("https://example.com/foo/bar")).toBe("jpg");
+  });
+});
+
+describe("_downloadMediaFor", () => {
+  beforeEach(() => {
+    axiosGetMock.mockReset();
+  });
+
+  it("downloads the image and returns an index-based filename alongside the data", async () => {
+    const buffer = Buffer.from("fake-image-bytes");
+    axiosGetMock.mockResolvedValue({ data: buffer });
+
+    const result = await _downloadMediaFor(
+      { name: "Jane Doe", party: "N/A", imageUrl: "https://example.com/jane.png" },
+      3,
+    );
+
+    expect(result).toEqual(["3.png", buffer]);
+    expect(axiosGetMock).toHaveBeenCalledWith(
+      "https://example.com/jane.png",
+      expect.objectContaining({ responseType: "arraybuffer" }),
+    );
+  });
+
+  it("skips a politician with an empty image URL without calling axios", async () => {
+    const result = await _downloadMediaFor({ name: "Jane Doe", party: "N/A", imageUrl: "" }, 0);
+
+    expect(result).toBeUndefined();
+    expect(axiosGetMock).not.toHaveBeenCalled();
+  });
+
+  it("skips a politician with a placeholder image URL without calling axios", async () => {
+    const result = await _downloadMediaFor(
+      { name: "Jane Doe", party: "N/A", imageUrl: "replace_this_image.jpg" },
+      0,
+    );
+
+    expect(result).toBeUndefined();
+    expect(axiosGetMock).not.toHaveBeenCalled();
+  });
+
+  it("skips (without throwing) when the download rejects", async () => {
+    axiosGetMock.mockRejectedValue(new Error("404 Not Found"));
+
+    const result = await _downloadMediaFor(
+      { name: "Jane Doe", party: "N/A", imageUrl: "https://example.com/broken.png" },
+      0,
+    );
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/ankiExporter.images.spec.js
+++ b/src/ankiExporter.images.spec.js
@@ -27,6 +27,14 @@ describe("_fileExtensionFor", () => {
   it("falls back to jpg when there is no extension at all", () => {
     expect(_fileExtensionFor("https://example.com/foo/bar")).toBe("jpg");
   });
+
+  it("ignores hash fragments when detecting the extension", () => {
+    expect(_fileExtensionFor("https://example.com/foo/bar.png#section")).toBe("png");
+  });
+
+  it("ignores a hash fragment that comes after a query string", () => {
+    expect(_fileExtensionFor("https://example.com/foo/bar.jpg?width=500#section")).toBe("jpg");
+  });
 });
 
 describe("_downloadMediaFor", () => {

--- a/src/ankiExporter.res
+++ b/src/ankiExporter.res
@@ -56,7 +56,8 @@ let cardFieldsFor = (politician: OutputHelpers.politician) => {
 
 // only the extensions Anki reliably renders inline; anything else falls back to jpg
 let _fileExtensionFor = (imageUrl: string): string => {
-  let withoutQuery = imageUrl->String.split("?")->Array.get(0)->Option.getOr(imageUrl)
+  let withoutHash = imageUrl->String.split("#")->Array.get(0)->Option.getOr(imageUrl)
+  let withoutQuery = withoutHash->String.split("?")->Array.get(0)->Option.getOr(withoutHash)
   switch withoutQuery->String.lastIndexOf(".") {
   | -1 => "jpg"
   | lastDot =>

--- a/src/ankiExporter.res
+++ b/src/ankiExporter.res
@@ -68,30 +68,21 @@ let _fileExtensionFor = (imageUrl: string): string => {
   }
 }
 
-// image downloads must never take the whole export down: a slow/broken Wikipedia URL
-// is common and should just yield a text-only card instead of failing all the others
+// a missing imageUrl is an expected, optional field and stays a soft skip (see
+// _downloadMediaFor below) — but a valid URL that fails to download points at a real bug
+// (e.g. the hardcoded-thumbnail-width issue), so that propagates and aborts the export
+// instead of silently shipping a deck with missing images
 let _imageConfig: Axios.axiosRequestConfig = {
   headers: Axios.defaultConfig.headers,
   responseType: "arraybuffer",
 }
 
-let _downloadImage = async (imageUrl: string): option<AnkiExport.mediaData> => {
-  try {
-    let response: Axios.response<AnkiExport.mediaData> = await Axios.get(
-      imageUrl,
-      Some(_imageConfig),
-    )
-    Some(response.data)
-  } catch {
-  | Exn.Error(e) =>
-    Console.log(
-      `⚠️  Skipping broken image ${imageUrl}: ${Exn.message(e)->Option.getOr("unknown error")}`,
-    )
-    None
-  | _ =>
-    Console.log(`⚠️  Skipping broken image ${imageUrl}`)
-    None
-  }
+let _downloadImage = async (imageUrl: string): AnkiExport.mediaData => {
+  let response: Axios.response<AnkiExport.mediaData> = await Axios.get(
+    imageUrl,
+    Some(_imageConfig),
+  )
+  response.data
 }
 
 // filename is index-based (not name-based) so it stays unique even for duplicate names
@@ -103,10 +94,8 @@ let _downloadMediaFor = async (politician: OutputHelpers.politician, index: int)
     Console.log(`⚠️  Skipping missing image for ${politician.name}`)
     None
   } else {
-    switch await _downloadImage(politician.imageUrl) {
-    | Some(data) => Some((`${index->Int.toString}.${_fileExtensionFor(politician.imageUrl)}`, data))
-    | None => None
-    }
+    let data = await _downloadImage(politician.imageUrl)
+    Some((`${index->Int.toString}.${_fileExtensionFor(politician.imageUrl)}`, data))
   }
 }
 

--- a/src/ankiExporter.res
+++ b/src/ankiExporter.res
@@ -11,8 +11,8 @@ let deserializePoliticians = (fileName): array<OutputHelpers.politician> => {
       | Some(fields) =>
         (
           {
-            amt: ?(fields->Dict.get("amt")->Option.flatMap(JSON.Decode.string)),
-            state: ?(fields->Dict.get("state")->Option.flatMap(JSON.Decode.string)),
+            amt: ?fields->Dict.get("amt")->Option.flatMap(JSON.Decode.string),
+            state: ?fields->Dict.get("state")->Option.flatMap(JSON.Decode.string),
             name: fields
             ->Dict.get("name")
             ->Option.getExn(~message="name field missing")
@@ -28,7 +28,7 @@ let deserializePoliticians = (fileName): array<OutputHelpers.politician> => {
             ->Option.getExn(~message="imageUrl field missing")
             ->JSON.Decode.string
             ->Option.getExn(~message="imageUrl field expected to be a string"),
-            urlCabinet: ?(fields->Dict.get("urlCabinet")->Option.flatMap(JSON.Decode.string)),
+            urlCabinet: ?fields->Dict.get("urlCabinet")->Option.flatMap(JSON.Decode.string),
           }: OutputHelpers.politician
         )
 

--- a/src/ankiExporter.res
+++ b/src/ankiExporter.res
@@ -11,8 +11,8 @@ let deserializePoliticians = (fileName): array<OutputHelpers.politician> => {
       | Some(fields) =>
         (
           {
-            amt: ?fields->Dict.get("amt")->Option.flatMap(JSON.Decode.string),
-            state: ?fields->Dict.get("state")->Option.flatMap(JSON.Decode.string),
+            amt: ?(fields->Dict.get("amt")->Option.flatMap(JSON.Decode.string)),
+            state: ?(fields->Dict.get("state")->Option.flatMap(JSON.Decode.string)),
             name: fields
             ->Dict.get("name")
             ->Option.getExn(~message="name field missing")
@@ -28,9 +28,10 @@ let deserializePoliticians = (fileName): array<OutputHelpers.politician> => {
             ->Option.getExn(~message="imageUrl field missing")
             ->JSON.Decode.string
             ->Option.getExn(~message="imageUrl field expected to be a string"),
-            urlCabinet: ?fields->Dict.get("urlCabinet")->Option.flatMap(JSON.Decode.string),
+            urlCabinet: ?(fields->Dict.get("urlCabinet")->Option.flatMap(JSON.Decode.string)),
           }: OutputHelpers.politician
         )
+
       | None => Error.panic(`Error deserializing single politician object from ${fileName}`)
       }
     })
@@ -53,13 +54,80 @@ let cardFieldsFor = (politician: OutputHelpers.politician) => {
   (front, `${politician.name} (${politician.party})`)
 }
 
+// only the extensions Anki reliably renders inline; anything else falls back to jpg
+let _fileExtensionFor = (imageUrl: string): string => {
+  let withoutQuery = imageUrl->String.split("?")->Array.get(0)->Option.getOr(imageUrl)
+  switch withoutQuery->String.lastIndexOf(".") {
+  | -1 => "jpg"
+  | lastDot =>
+    switch withoutQuery->String.sliceToEnd(~start=lastDot + 1)->String.toLowerCase {
+    | ("jpg" | "jpeg" | "png" | "gif" | "webp") as ext => ext
+    | _ => "jpg"
+    }
+  }
+}
+
+// image downloads must never take the whole export down: a slow/broken Wikipedia URL
+// is common and should just yield a text-only card instead of failing all the others
+let _imageConfig: Axios.axiosRequestConfig = {
+  headers: Axios.defaultConfig.headers,
+  responseType: "arraybuffer",
+}
+
+let _downloadImage = async (imageUrl: string): option<AnkiExport.mediaData> => {
+  try {
+    let response: Axios.response<AnkiExport.mediaData> = await Axios.get(
+      imageUrl,
+      Some(_imageConfig),
+    )
+    Some(response.data)
+  } catch {
+  | Exn.Error(e) =>
+    Console.log(
+      `⚠️  Skipping broken image ${imageUrl}: ${Exn.message(e)->Option.getOr("unknown error")}`,
+    )
+    None
+  | _ =>
+    Console.log(`⚠️  Skipping broken image ${imageUrl}`)
+    None
+  }
+}
+
+// filename is index-based (not name-based) so it stays unique even for duplicate names
+let _downloadMediaFor = async (politician: OutputHelpers.politician, index: int): option<(
+  string,
+  AnkiExport.mediaData,
+)> => {
+  if !OutputHelpers.hasValidImageUrl(politician) {
+    Console.log(`⚠️  Skipping missing image for ${politician.name}`)
+    None
+  } else {
+    switch await _downloadImage(politician.imageUrl) {
+    | Some(data) => Some((`${index->Int.toString}.${_fileExtensionFor(politician.imageUrl)}`, data))
+    | None => None
+    }
+  }
+}
+
 let exportJsonFileToApkg = async (jsonFilePath, outputFilePath, deckName) => {
   let politicians = deserializePoliticians(jsonFilePath)
   let deck = AnkiExport.make(deckName)
-  politicians->Array.forEach(politician => {
+
+  let media = await Promise.all(
+    politicians->Array.mapWithIndex((politician, index) => _downloadMediaFor(politician, index)),
+  )
+
+  politicians->Array.forEachWithIndex((politician, index) => {
     let (front, back) = cardFieldsFor(politician)
+    let back = switch media->Array.get(index)->Option.flatMap(x => x) {
+    | Some((filename, data)) =>
+      AnkiExport.addMedia(deck, filename, data)
+      `${back}<br><img src="${filename}">`
+    | None => back
+    }
     AnkiExport.addCard(deck, front, back)
   })
+
   let data = await AnkiExport.save(deck)
   AnkiExport.writeFileSync(outputFilePath, data)
   Console.log(`Wrote ${politicians->Array.length->Int.toString} cards to ${outputFilePath}`)

--- a/src/axios.res
+++ b/src/axios.res
@@ -1,11 +1,10 @@
 type request
 
-type axiosHeaders = {
-  @as("User-Agent") userAgent: string,
-}
+type axiosHeaders = {@as("User-Agent") userAgent: string}
 
 type axiosRequestConfig = {
   headers: axiosHeaders,
+  responseType?: string,
 }
 
 type response<'dataType> = {

--- a/src/outputHelpers.res
+++ b/src/outputHelpers.res
@@ -30,15 +30,17 @@ let writeAsJson = (fileName: string, output: array<politician>, ~writeFileSyncWi
   }
 }
 
+let hasValidImageUrl = (minister: politician) => {
+  minister.imageUrl != "" &&
+  !(minister.imageUrl->String.includes("replace_this_image")) &&
+  !(minister.imageUrl->String.includes("Placeholder"))
+}
+
 let formatImageUrl = (minister: politician) => {
-  if (
-    minister.imageUrl == "" ||
-    minister.imageUrl->String.includes("replace_this_image") ||
-    minister.imageUrl->String.includes("Placeholder")
-  ) {
-    "*Kein Bild verfügbar*"
-  } else {
+  if hasValidImageUrl(minister) {
     `![${minister.name}](${minister.imageUrl})`
+  } else {
+    "*Kein Bild verfügbar*"
   }
 }
 


### PR DESCRIPTION
Closes #49.

## Summary
- `AnkiExporter._downloadMediaFor` downloads each politician's `imageUrl` via axios (`responseType: "arraybuffer"`), returning an index-based filename (`0.jpg`, `1.png`, ...) paired with the raw bytes.
- `exportJsonFileToApkg` downloads all images concurrently (`Promise.all`), then adds each one to the deck via the newly-bound `AnkiExport.addMedia`, and appends `<img src="...">` to the card's back field.
- Extension is sniffed from the URL path (falls back to `jpg` for unknown/missing extensions); filenames are index-based rather than name-based so duplicates can't collide.
- `OutputHelpers.hasValidImageUrl` was extracted out of the existing markdown `formatImageUrl` placeholder check (empty / `replace_this_image` / `Placeholder`) and reused here, so politicians without a real photo are skipped up front with a log line and never hit the network.
- ~~A failed download (bad URL, non-2xx, network error) is caught individually and logged — it degrades that one card to text-only rather than failing the whole export.~~ **Update:** per review discussion, this was changed — a valid `imageUrl` whose download fails now propagates and aborts the export instead of degrading silently. A missing/placeholder `imageUrl` is still a soft, expected skip. See https://github.com/Husterknupp/party-insights-shenanigans/pull/56#issuecomment-5012618130.

## Acceptance criteria
- [x] Images are downloaded and bundled into the .apkg
- [x] Cards display the image when reviewed
- [x] Missing image URLs don't crash the export (skip + log instead)
- [x] Broken image URLs (valid URL, failed download) abort the export loudly instead of shipping an incomplete deck

## Test plan
- [x] `npm run res:build` — clean compile
- [x] `npm test` — 52/52 passing (added `src/ankiExporter.images.spec.js`, mocking axios via `jest.unstable_mockModule`, covering extension sniffing, successful download + filename, missing/placeholder URL skip, and rejected-download throwing)
- [x] Manual end-to-end run: `node exportAnkiDeck.js output/ministerpraesidenten.json` produced a 16-card `.apkg`; unzipped and verified with `sqlite3`/`file` that the `media` manifest, the embedded JPEG bytes, and the `<img src="N.jpg">` tags in `notes.flds` all line up.
- Also ran against `output/bundesregierung.json` and `output/landesregierungen/bremen.json`: several of their `imageUrl`s point at Wikimedia thumbnail widths that Wikimedia's servers now reject with 400 ("Use thumbnail sizes listed..."). This is exactly the failure mode that led to the update above: with the original skip-and-log behavior, that thumbnail-width bug would have silently shipped decks missing images. It has since been fixed at the source in `bundesregierung.js` (500px instead of the rejected 400px), and the download path now fails loudly instead of masking issues like it in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anki exports now include available politician images as attached card media.
  * Card backs now display the image when available, alongside the existing text content.
* **Bug Fixes**
  * Improved image URL validation with consistent fallback text when images can’t be used.
  * Media download now detects safe extensions (ignoring query/hash), and skips failures without aborting exports; invalid/placeholder image URLs are ignored.
* **Tests**
  * Added coverage for extension detection and media download behavior, including success, placeholder, and network failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
