### PR TITLE
Fix broken images in Bundesregierung (request 500px thumbnails)

### DIFF
--- a/output/bundesregierung.json
+++ b/output/bundesregierung.json
@@ -2,109 +2,109 @@
   {
     "amt": "Auswärtiges Amt (AA)",
     "name": "Johann Wadephul",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Wadephul%2C_Johann-1249.jpg/400px-Wadephul%2C_Johann-1249.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Wadephul%2C_Johann-1249.jpg/500px-Wadephul%2C_Johann-1249.jpg",
     "party": "CDU"
   },
   {
     "amt": "Bundeskanzler",
     "name": "Friedrich Merz",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93076_%28cropped%29.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93076_%28cropped%29.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93076_%28cropped%29.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93076_%28cropped%29.jpg",
     "party": "CDU"
   },
   {
     "amt": "Bundesminister für besondere Aufgaben • Chef des Bundeskanzleramtes",
     "name": "Thorsten Frei",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Thorsten_Frei_2023_%28cropped%29.jpg/400px-Thorsten_Frei_2023_%28cropped%29.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Thorsten_Frei_2023_%28cropped%29.jpg/500px-Thorsten_Frei_2023_%28cropped%29.jpg",
     "party": "CDU"
   },
   {
     "amt": "Bundesministerium der Justiz und für Verbraucherschutz (BMJV)",
     "name": "Stefanie Hubig",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93118.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93118.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93118.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93118.jpg",
     "party": "SPD"
   },
   {
     "amt": "Bundesministerium der Verteidigung (BMVg)",
     "name": "Boris Pistorius",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Boris_Pistorius_%282019%29_%28cropped%29.jpg/400px-Boris_Pistorius_%282019%29_%28cropped%29.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Boris_Pistorius_%282019%29_%28cropped%29.jpg/500px-Boris_Pistorius_%282019%29_%28cropped%29.jpg",
     "party": "SPD"
   },
   {
     "amt": "Bundesministerium für Arbeit und Soziales (BMAS)",
     "name": "Bärbel Bas",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93033.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93033.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93033.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93033.jpg",
     "party": "SPD"
   },
   {
     "amt": "Bundesministerium für Bildung, Familie, Senioren, Frauen und Jugend (BMBFSFJ)",
     "name": "Karin Prien",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/2025-02-23_Bundestagswahl_%E2%80%93_Wahlabend_CDU_by_Sandro_Halank%E2%80%93083.jpg/400px-2025-02-23_Bundestagswahl_%E2%80%93_Wahlabend_CDU_by_Sandro_Halank%E2%80%93083.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/2025-02-23_Bundestagswahl_%E2%80%93_Wahlabend_CDU_by_Sandro_Halank%E2%80%93083.jpg/500px-2025-02-23_Bundestagswahl_%E2%80%93_Wahlabend_CDU_by_Sandro_Halank%E2%80%93083.jpg",
     "party": "CDU"
   },
   {
     "amt": "Bundesministerium für Digitales und Staatsmodernisierung (BMDS)",
     "name": "Karsten Wildberger",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2b/Karsten_WILDBERGER_%28Federal_Minister_for_Digital_and_State_Modernisation%2C_Germany%29.jpg/400px-Karsten_WILDBERGER_%28Federal_Minister_for_Digital_and_State_Modernisation%2C_Germany%29.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2b/Karsten_WILDBERGER_%28Federal_Minister_for_Digital_and_State_Modernisation%2C_Germany%29.jpg/500px-Karsten_WILDBERGER_%28Federal_Minister_for_Digital_and_State_Modernisation%2C_Germany%29.jpg",
     "party": "CDU"
   },
   {
     "amt": "Bundesministerium für Forschung, Technologie und Raumfahrt (BMFTR)",
     "name": "Dorothee Bär",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/aa/Hart_aber_fair_2024-12-02-8076.jpg/400px-Hart_aber_fair_2024-12-02-8076.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/aa/Hart_aber_fair_2024-12-02-8076.jpg/500px-Hart_aber_fair_2024-12-02-8076.jpg",
     "party": "CSU"
   },
   {
     "amt": "Bundesministerium für Gesundheit (BMG)",
     "name": "Nina Warken",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/2020-02-13_Deutscher_Bundestag_IMG_3091_by_Stepro.jpg/400px-2020-02-13_Deutscher_Bundestag_IMG_3091_by_Stepro.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/2020-02-13_Deutscher_Bundestag_IMG_3091_by_Stepro.jpg/500px-2020-02-13_Deutscher_Bundestag_IMG_3091_by_Stepro.jpg",
     "party": "CDU"
   },
   {
     "amt": "Bundesministerium für Landwirtschaft, Ernährung und Heimat (BMELH)",
     "name": "Alois Rainer",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_%28Martin_Rulsch%29_160.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_%28Martin_Rulsch%29_160.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_%28Martin_Rulsch%29_160.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_%28Martin_Rulsch%29_160.jpg",
     "party": "CSU"
   },
   {
     "amt": "Bundesministerium für Umwelt, Klimaschutz, Naturschutz und nukleare Sicherheit (BMUKN)",
     "name": "Carsten Schneider",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93038.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93038.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93038.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93038.jpg",
     "party": "SPD"
   },
   {
     "amt": "Bundesministerium für Verkehr (BMV)",
     "name": "Patrick Schnieder",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Schnieder%2C_Patrick-1239.jpg/400px-Schnieder%2C_Patrick-1239.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Schnieder%2C_Patrick-1239.jpg/500px-Schnieder%2C_Patrick-1239.jpg",
     "party": "CDU"
   },
   {
     "amt": "Bundesministerium für Wirtschaft und Energie (BMWE)",
     "name": "Katherina Reiche",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Katherina_Reiche_2025-05-15_%28cropped%29.jpg/400px-Katherina_Reiche_2025-05-15_%28cropped%29.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Katherina_Reiche_2025-05-15_%28cropped%29.jpg/500px-Katherina_Reiche_2025-05-15_%28cropped%29.jpg",
     "party": "CDU"
   },
   {
     "amt": "Bundesministerium für wirtschaftliche Zusammenarbeit und Entwicklung (BMZ)",
     "name": "Reem Alabali Radovan",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/00/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93035.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93035.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/00/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93035.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93035.jpg",
     "party": "SPD"
   },
   {
     "amt": "Bundesministerium für Wohnen, Stadtentwicklung und Bauwesen (BMWSB)",
     "name": "Verena Hubertz",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93034.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93034.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93034.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93034.jpg",
     "party": "SPD"
   },
   {
     "amt": "Stellvertreter des Bundeskanzlers • Bundesministerium der Finanzen (BMF)",
     "name": "Lars Klingbeil",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/Wahlkampf_Landtagswahl_NRW_2022_-_SPD_-_Roncalliplatz_K%C3%B6ln_2022-05-13-4265_Crop_3.jpg/400px-Wahlkampf_Landtagswahl_NRW_2022_-_SPD_-_Roncalliplatz_K%C3%B6ln_2022-05-13-4265_Crop_3.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/Wahlkampf_Landtagswahl_NRW_2022_-_SPD_-_Roncalliplatz_K%C3%B6ln_2022-05-13-4265_Crop_3.jpg/500px-Wahlkampf_Landtagswahl_NRW_2022_-_SPD_-_Roncalliplatz_K%C3%B6ln_2022-05-13-4265_Crop_3.jpg",
     "party": "SPD"
   },
   {
     "amt": "Vertreter nach § 22 (1) S. 2 Alt. 1 GO-BReg • Bundesministerium des Innern (BMI)",
     "name": "Alexander Dobrindt",
-    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93127.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93127.jpg",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93127.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93127.jpg",
     "party": "CSU"
   }
 ]

--- a/output/bundesregierung.md
+++ b/output/bundesregierung.md
@@ -3,89 +3,89 @@
 Auswärtiges Amt (AA):
 * Name: Johann Wadephul
 * Partei: CDU
-* Profilbild: ![Johann Wadephul](https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Wadephul%2C_Johann-1249.jpg/400px-Wadephul%2C_Johann-1249.jpg)
+* Profilbild: ![Johann Wadephul](https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Wadephul%2C_Johann-1249.jpg/500px-Wadephul%2C_Johann-1249.jpg)
 
 Bundeskanzler:
 * Name: Friedrich Merz
 * Partei: CDU
-* Profilbild: ![Friedrich Merz](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93076_%28cropped%29.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93076_%28cropped%29.jpg)
+* Profilbild: ![Friedrich Merz](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93076_%28cropped%29.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93076_%28cropped%29.jpg)
 
 Bundesminister für besondere Aufgaben • Chef des Bundeskanzleramtes:
 * Name: Thorsten Frei
 * Partei: CDU
-* Profilbild: ![Thorsten Frei](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Thorsten_Frei_2023_%28cropped%29.jpg/400px-Thorsten_Frei_2023_%28cropped%29.jpg)
+* Profilbild: ![Thorsten Frei](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Thorsten_Frei_2023_%28cropped%29.jpg/500px-Thorsten_Frei_2023_%28cropped%29.jpg)
 
 Bundesministerium der Justiz und für Verbraucherschutz (BMJV):
 * Name: Stefanie Hubig
 * Partei: SPD
-* Profilbild: ![Stefanie Hubig](https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93118.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93118.jpg)
+* Profilbild: ![Stefanie Hubig](https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93118.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93118.jpg)
 
 Bundesministerium der Verteidigung (BMVg):
 * Name: Boris Pistorius
 * Partei: SPD
-* Profilbild: ![Boris Pistorius](https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Boris_Pistorius_%282019%29_%28cropped%29.jpg/400px-Boris_Pistorius_%282019%29_%28cropped%29.jpg)
+* Profilbild: ![Boris Pistorius](https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Boris_Pistorius_%282019%29_%28cropped%29.jpg/500px-Boris_Pistorius_%282019%29_%28cropped%29.jpg)
 
 Bundesministerium für Arbeit und Soziales (BMAS):
 * Name: Bärbel Bas
 * Partei: SPD
-* Profilbild: ![Bärbel Bas](https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93033.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93033.jpg)
+* Profilbild: ![Bärbel Bas](https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93033.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93033.jpg)
 
 Bundesministerium für Bildung, Familie, Senioren, Frauen und Jugend (BMBFSFJ):
 * Name: Karin Prien
 * Partei: CDU
-* Profilbild: ![Karin Prien](https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/2025-02-23_Bundestagswahl_%E2%80%93_Wahlabend_CDU_by_Sandro_Halank%E2%80%93083.jpg/400px-2025-02-23_Bundestagswahl_%E2%80%93_Wahlabend_CDU_by_Sandro_Halank%E2%80%93083.jpg)
+* Profilbild: ![Karin Prien](https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/2025-02-23_Bundestagswahl_%E2%80%93_Wahlabend_CDU_by_Sandro_Halank%E2%80%93083.jpg/500px-2025-02-23_Bundestagswahl_%E2%80%93_Wahlabend_CDU_by_Sandro_Halank%E2%80%93083.jpg)
 
 Bundesministerium für Digitales und Staatsmodernisierung (BMDS):
 * Name: Karsten Wildberger
 * Partei: CDU
-* Profilbild: ![Karsten Wildberger](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2b/Karsten_WILDBERGER_%28Federal_Minister_for_Digital_and_State_Modernisation%2C_Germany%29.jpg/400px-Karsten_WILDBERGER_%28Federal_Minister_for_Digital_and_State_Modernisation%2C_Germany%29.jpg)
+* Profilbild: ![Karsten Wildberger](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2b/Karsten_WILDBERGER_%28Federal_Minister_for_Digital_and_State_Modernisation%2C_Germany%29.jpg/500px-Karsten_WILDBERGER_%28Federal_Minister_for_Digital_and_State_Modernisation%2C_Germany%29.jpg)
 
 Bundesministerium für Forschung, Technologie und Raumfahrt (BMFTR):
 * Name: Dorothee Bär
 * Partei: CSU
-* Profilbild: ![Dorothee Bär](https://upload.wikimedia.org/wikipedia/commons/thumb/a/aa/Hart_aber_fair_2024-12-02-8076.jpg/400px-Hart_aber_fair_2024-12-02-8076.jpg)
+* Profilbild: ![Dorothee Bär](https://upload.wikimedia.org/wikipedia/commons/thumb/a/aa/Hart_aber_fair_2024-12-02-8076.jpg/500px-Hart_aber_fair_2024-12-02-8076.jpg)
 
 Bundesministerium für Gesundheit (BMG):
 * Name: Nina Warken
 * Partei: CDU
-* Profilbild: ![Nina Warken](https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/2020-02-13_Deutscher_Bundestag_IMG_3091_by_Stepro.jpg/400px-2020-02-13_Deutscher_Bundestag_IMG_3091_by_Stepro.jpg)
+* Profilbild: ![Nina Warken](https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/2020-02-13_Deutscher_Bundestag_IMG_3091_by_Stepro.jpg/500px-2020-02-13_Deutscher_Bundestag_IMG_3091_by_Stepro.jpg)
 
 Bundesministerium für Landwirtschaft, Ernährung und Heimat (BMELH):
 * Name: Alois Rainer
 * Partei: CSU
-* Profilbild: ![Alois Rainer](https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_%28Martin_Rulsch%29_160.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_%28Martin_Rulsch%29_160.jpg)
+* Profilbild: ![Alois Rainer](https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_%28Martin_Rulsch%29_160.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_%28Martin_Rulsch%29_160.jpg)
 
 Bundesministerium für Umwelt, Klimaschutz, Naturschutz und nukleare Sicherheit (BMUKN):
 * Name: Carsten Schneider
 * Partei: SPD
-* Profilbild: ![Carsten Schneider](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93038.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93038.jpg)
+* Profilbild: ![Carsten Schneider](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93038.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93038.jpg)
 
 Bundesministerium für Verkehr (BMV):
 * Name: Patrick Schnieder
 * Partei: CDU
-* Profilbild: ![Patrick Schnieder](https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Schnieder%2C_Patrick-1239.jpg/400px-Schnieder%2C_Patrick-1239.jpg)
+* Profilbild: ![Patrick Schnieder](https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Schnieder%2C_Patrick-1239.jpg/500px-Schnieder%2C_Patrick-1239.jpg)
 
 Bundesministerium für Wirtschaft und Energie (BMWE):
 * Name: Katherina Reiche
 * Partei: CDU
-* Profilbild: ![Katherina Reiche](https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Katherina_Reiche_2025-05-15_%28cropped%29.jpg/400px-Katherina_Reiche_2025-05-15_%28cropped%29.jpg)
+* Profilbild: ![Katherina Reiche](https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Katherina_Reiche_2025-05-15_%28cropped%29.jpg/500px-Katherina_Reiche_2025-05-15_%28cropped%29.jpg)
 
 Bundesministerium für wirtschaftliche Zusammenarbeit und Entwicklung (BMZ):
 * Name: Reem Alabali Radovan
 * Partei: SPD
-* Profilbild: ![Reem Alabali Radovan](https://upload.wikimedia.org/wikipedia/commons/thumb/0/00/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93035.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93035.jpg)
+* Profilbild: ![Reem Alabali Radovan](https://upload.wikimedia.org/wikipedia/commons/thumb/0/00/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93035.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93035.jpg)
 
 Bundesministerium für Wohnen, Stadtentwicklung und Bauwesen (BMWSB):
 * Name: Verena Hubertz
 * Partei: SPD
-* Profilbild: ![Verena Hubertz](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93034.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93034.jpg)
+* Profilbild: ![Verena Hubertz](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93034.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93034.jpg)
 
 Stellvertreter des Bundeskanzlers • Bundesministerium der Finanzen (BMF):
 * Name: Lars Klingbeil
 * Partei: SPD
-* Profilbild: ![Lars Klingbeil](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/Wahlkampf_Landtagswahl_NRW_2022_-_SPD_-_Roncalliplatz_K%C3%B6ln_2022-05-13-4265_Crop_3.jpg/400px-Wahlkampf_Landtagswahl_NRW_2022_-_SPD_-_Roncalliplatz_K%C3%B6ln_2022-05-13-4265_Crop_3.jpg)
+* Profilbild: ![Lars Klingbeil](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/Wahlkampf_Landtagswahl_NRW_2022_-_SPD_-_Roncalliplatz_K%C3%B6ln_2022-05-13-4265_Crop_3.jpg/500px-Wahlkampf_Landtagswahl_NRW_2022_-_SPD_-_Roncalliplatz_K%C3%B6ln_2022-05-13-4265_Crop_3.jpg)
 
 Vertreter nach § 22 (1) S. 2 Alt. 1 GO-BReg • Bundesministerium des Innern (BMI):
 * Name: Alexander Dobrindt
 * Partei: CSU
-* Profilbild: ![Alexander Dobrindt](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93127.jpg/400px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93127.jpg)
+* Profilbild: ![Alexander Dobrindt](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93127.jpg/500px-2025-05-05_Unterzeichnung_des_Koalitionsvertrages_der_21._Wahlperiode_des_Bundestages_by_Sandro_Halank%E2%80%93127.jpg)

--- a/src/bundesregierung.js
+++ b/src/bundesregierung.js
@@ -5,12 +5,14 @@ import axios from "axios";
 import { load } from "cheerio";
 import { writeAsJson, writeAsMarkdown } from "./outputHelpers.res.mjs";
 
-function urlForResizedImage(image) {
+export function urlForResizedImage(image) {
   // Resize image to non-thumb size
   // thumb Format: //upload.wikimedia.org/wikipedia/commons/thumb/5/5f/2022-02-21_Dr._Markus_Soeder-1926_%28cropped%29.jpg/74px-2022-02-21_Dr._Markus_Soeder-1926_%28cropped%29.jpg
+  // Use 500px thumbnail (defined MediaWiki size, see mediawiki.org/wiki/Common_thumbnail_sizes);
+  // Wikimedia's servers reject non-standard widths like 400px with a 400 Bad Request.
   let parts = image.split("/");
   parts = parts.filter((_, index) => index !== parts.length - 1);
-  parts.push("400px-" + parts[parts.length - 1]);
+  parts.push("500px-" + parts[parts.length - 1]);
   return "https:" + parts.join("/");
 }
 

--- a/src/bundesregierung.spec.js
+++ b/src/bundesregierung.spec.js
@@ -1,10 +1,19 @@
 import { load } from "cheerio";
 import htmlFromWikipedia from "../test-data/bundesregierung.js";
-import { findRelevantTable } from "./bundesregierung.js";
+import { findRelevantTable, urlForResizedImage } from "./bundesregierung.js";
 
 describe("Bundesregierung extractor", () => {
   test("findRelevantTable works (and throws no exception)", () => {
     const $ = load(htmlFromWikipedia);
     findRelevantTable($);
+  });
+
+  test("urlForResizedImage requests a 500px thumbnail (400px is rejected by Wikimedia with a 400)", () => {
+    const thumbUrl =
+      "//upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Wadephul%2C_Johann-1249.jpg/74px-Wadephul%2C_Johann-1249.jpg";
+
+    expect(urlForResizedImage(thumbUrl)).toBe(
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Wadephul%2C_Johann-1249.jpg/500px-Wadephul%2C_Johann-1249.jpg",
+    );
   });
 });


### PR DESCRIPTION
Closes #57.

## Summary
- `urlForResizedImage` in `src/bundesregierung.js` hardcoded a `400px-` thumbnail width. Wikimedia's servers now reject that specific width with HTTP 400 (`Use thumbnail sizes listed on https://w.wiki/GHai`), so **every** image in the Bundesregierung deck was silently skipped by the (correctly working) skip-and-log logic added in #56.
- Switched to `500px-`, the same documented MediaWiki common thumbnail size (mediawiki.org/wiki/Common_thumbnail_sizes) already used in `ministerpraesidenten.js`.
- Regenerated `output/bundesregierung.json` and `output/bundesregierung.md` via `npm start` so the checked-in output matches what CI's "Check For Wiki Updates" workflow expects.

## Root cause (for context)
Verified directly with `curl` on the same file:
- `.../400px-Wadephul%2C_Johann-1249.jpg` → HTTP 400
- `.../500px-Wadephul%2C_Johann-1249.jpg` → HTTP 200

## Test plan
- [x] `npm run res:build` — clean compile
- [x] `npm test` — 43/43 passing (added a unit test for `urlForResizedImage` in `src/bundesregierung.spec.js`)
- [x] `npm start` on a clean checkout first confirmed the existing committed output already matched a fresh scrape (no CI drift from unrelated sources), then re-ran with the fix applied — only `output/bundesregierung.{json,md}` changed, `ministerpraesidenten` and `landesregierungen` output untouched
- [x] Curled all 18 resulting `bundesregierung.json` image URLs individually (with delay to avoid rate-limiting) — all 18/18 now return HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated profile images in the Bundesregierung roster to use higher-resolution 500px thumbnails.
  * Standardized roster entries in the displayed Markdown format for clearer presentation.

* **Tests**
  * Added coverage to verify that profile image URLs are converted to the new 500px thumbnail format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->