### PR TITLE
docs(#52): document Anki/AnkiDroid import + missing res:build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,15 @@ npm test
 ## Export an Anki Deck
 
 ```shell
+npm ci
+npm run res:build
 npm run export:anki -- output/<file>.json
 ```
+
+`output/<file>.json` is one of the already-committed files in [`output/`](./output)
+(e.g. `output/bundesregierung.json`) — no need to run the full scrape first. `res:build`
+is required: the exporter is written in ReScript, and its compiled `.res.mjs` output
+isn't checked in.
 
 Produces `output/<file>.apkg` next to the input JSON, importable into Anki/AnkiDroid.
 
@@ -42,3 +49,20 @@ The fields and card templates are defined once, as the `POLITICIAN_FIELDS` and
 `POLITICIAN_TEMPLATES` constants in [`src/politicianNoteTypeSql.js`](./src/politicianNoteTypeSql.js) —
 that's the single place to edit if the layout needs to change; `src/ankiApkgExportFacade.res` only
 binds into it, it doesn't build any template itself.
+
+### Import the `.apkg` into Anki
+
+**Desktop (Anki):** with Anki running, double-click the `.apkg` file — or use
+File → Import… and select it. Either way, Anki adds the deck's cards to your
+collection.
+
+**Mobile (AnkiDroid):** first get the `.apkg` file onto the phone (e.g. via
+USB, cloud storage, or email), then:
+
+1. Open AnkiDroid and tap the overflow menu (⋮, top-right, next to search and sync).
+2. Tap **Importieren** (Import).
+3. Choose **Stapel-Paket (.apkg)** ("Deck Package (.apkg)") and pick the file.
+
+AnkiDroid's menu labels above are German (matching the screenshots this was
+transcribed from); the English AnkiDroid build uses the same three-dot menu →
+**Import** → **Deck Package (.apkg)**.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,4 @@ USB, cloud storage, or email), then:
 2. Tap **Importieren** (Import).
 3. Choose **Stapel-Paket (.apkg)** ("Deck Package (.apkg)") and pick the file.
 
-AnkiDroid's menu labels above are German (matching the screenshots this was
-transcribed from); the English AnkiDroid build uses the same three-dot menu →
-**Import** → **Deck Package (.apkg)**.
+(Labels above are German; the English build uses the same menu → **Import** → **Deck Package (.apkg)**.)


### PR DESCRIPTION
## Summary

- Adds a "Import the `.apkg` into Anki" section to the README, covering desktop Anki and AnkiDroid (mobile) explicitly, per #52's remaining ACs.
- The AnkiDroid steps are transcribed from the three screenshots Husterknupp attached to #52, rather than embedded as images — per his ask to keep the README clean. Verified the English AnkiDroid menu wording independently (three-dot menu → Import → Deck package) instead of assuming a translation.
- Fixes a real gap found while dry-running the README end-to-end (AC #4): "Export an Anki Deck" only listed `npm run export:anki`, but that script imports the ReScript-compiled `ankiExporter.res.mjs`, which isn't checked in. Running it from a genuinely fresh clone without `npm run res:build` first fails with `ERR_MODULE_NOT_FOUND`. Reproduced against a real fresh clone (`git clone` into `/tmp`, `npm ci`, run without `res:build` → fails; with `res:build` → succeeds) before writing the fix.

Closes #52.

## Test plan
- [x] Reproduced the missing-build-step failure against a real fresh clone, then confirmed the fix resolves it
- [x] `npm test`: 79/79 passing
- [x] Full README dry run: `npm ci` → `npm run res:build` → `npm run export:anki -- output/bundesregierung.json` → produces a working `.apkg`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Anki export instructions to include dependency installation, resource building, and export steps.
  * Clarified requirements for using an existing committed JSON output file.
  * Added separate desktop and mobile Anki import guidance, including German and English menu labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->