### PR TITLE
#65 Rely on JSON Diff in CI

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -23,6 +23,5 @@ jobs:
       # ACTUAL CHECK
       - name: Compare output with checked-in version
         run: |
-          git status --porcelain
-          STATUS=$(git status --porcelain)
-          if [[ ! $STATUS ]]; then echo "empty"; else git --no-pager diff && exit 1; fi
+          STATUS=$(git status --porcelain -- . ':(exclude)output/**/*.apkg')
+          if [[ ! $STATUS ]]; then echo "empty"; else git --no-pager diff -- . ':(exclude)output/**/*.apkg' && exit 1; fi

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -23,5 +23,5 @@ jobs:
       # ACTUAL CHECK
       - name: Compare output with checked-in version
         run: |
-          STATUS=$(git status --porcelain -- . ':(exclude)output/**/*.apkg')
-          if [[ ! $STATUS ]]; then echo "empty"; else git --no-pager diff -- . ':(exclude)output/**/*.apkg' && exit 1; fi
+          STATUS=$(git status --porcelain -- . ':(glob,exclude)output/**/*.apkg')
+          if [[ ! $STATUS ]]; then echo "empty"; else git --no-pager diff -- . ':(glob,exclude)output/**/*.apkg' && exit 1; fi


### PR DESCRIPTION
Closes #65.

Anki deck generation produces different bytes for the same input on consecutive runs. So every CI run will look like there are chã ces where actually nothing meaningful changed. 

Json and markdown are more reliable indicators. When they change, we also need to generate anki decks new through npm start

See also #66 for a more thorough approach 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automated output checks to ignore generated package files, preventing false failures when these files differ from the checked-in versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->