### PR TITLE
fix(#71): stable note guids so re-importing a deck updates instead of duplicating

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,37 @@ USB, cloud storage, or email), then:
 3. Choose **Stapel-Paket (.apkg)** ("Deck Package (.apkg)") and pick the file.
 
 (Labels above are German; the English build uses the same menu → **Import** → **Deck Package (.apkg)**.)
+
+### Re-importing an updated deck
+
+Cabinets change, so the decks are regenerated. Importing a newer `.apkg` on top of a deck
+you already have is the intended way to update it, and Anki decides what to do per note:
+
+- **Nothing changed** — the note is updated in place. Your intervals, due dates and review
+  history are untouched.
+- **Only the photo changed** — likewise updated in place. A new portrait is not a new fact,
+  so it does not cost you your progress on that card.
+- **A new person on a post, a party switch, a renamed ministry** — this is a new fact to
+  learn, so it arrives as a **new card** and you are asked it straight away rather than in
+  however many months the old card was next due.
+
+#### Politicians who left have to be deleted by hand
+
+An `.apkg` can only add or update notes. There is no way for it to express "this person is
+no longer in office", so someone who left the cabinet stays in your collection until you
+remove them — and after a reshuffle you will have two cards asking the same question with
+different answers.
+
+Anki tells you which is which: the browser shows the older card with a due date
+("fällig am …") while the replacement is still listed as new ("Neu #123"). Open the browser
+(**Durchsuchen** / Browse), select the deck, sort by **Fällig** (Due), and delete the notes
+for people who are no longer listed.
+
+#### One-time duplication when upgrading from a deck exported before mid-2026
+
+Decks generated before this change identified their notes in a way that changed on every
+export ([#71](https://github.com/Husterknupp/party-insights-shenanigans/issues/71)), so
+Anki could never recognise a re-import. Notes you imported from one of those older decks
+will not be matched by the new ones, and your **next** import will duplicate the deck once.
+Delete the old copies afterwards; every import from then on updates in place as described
+above.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ you already have is the intended way to update it, and Anki decides what to do p
   learn, so it arrives as a **new card** and you are asked it straight away rather than in
   however many months the old card was next due.
 
+Updating in place has one condition: Anki only overwrites a note it already has when the
+file you are importing is newer than the one you imported last, which every freshly
+generated deck is — each one is stamped with the time it was built. (Import the very same
+file a second time and there is nothing newer to write, so Anki leaves your collection
+exactly as it is and reports those notes as unchanged rather than updated.)
+
 #### Politicians who left have to be deleted by hand
 
 An `.apkg` can only add or update notes. There is no way for it to express "this person is

--- a/src/apkgFileExport.integration.spec.js
+++ b/src/apkgFileExport.integration.spec.js
@@ -45,12 +45,12 @@ const readNotesAndCards = async (apkgFilePath) => {
   const collectionData = await collectionFile.async("uint8array");
   const db = new SQL.Database(collectionData);
 
-  const notes = db.exec("select id, flds from notes")[0]?.values ?? [];
+  const notes = db.exec("select id, guid, flds from notes")[0]?.values ?? [];
   const cards = db.exec("select nid from cards")[0]?.values ?? [];
 
   return {
     zip,
-    notes: notes.map(([id, flds]) => ({ id, flds })),
+    notes: notes.map(([id, guid, flds]) => ({ id, guid, flds })),
     cardCountByNoteId: cards.reduce((counts, [nid]) => {
       counts.set(nid, (counts.get(nid) ?? 0) + 1);
       return counts;
@@ -105,5 +105,98 @@ describe("exportOutputFileToApkg (integration, real anki-apkg-export)", () => {
 
     expect(cardCountByNoteId.get(erikaNote.id)).toBe(2);
     expect(cardCountByNoteId.get(maxNote.id)).toBe(1);
+  });
+});
+
+// #71: what a *re*-import does, which is decided entirely by the note guids the export writes.
+// Anki matches an incoming note against the collection by guid alone — a match updates the note's
+// fields and leaves its cards and their scheduling untouched, a miss adds a new note whose cards go
+// into the new queue. So "does the user keep their progress" and "is the user shown the change" are
+// both questions about guid equality between two exports, which is what these assert. The import
+// itself is simulated by taking the union of the two guid sets, exactly what Anki keys on.
+describe("exportOutputFileToApkg re-export identity", () => {
+  const IMAGE_CHANGED = {
+    ...POLITICIAN_WITH_IMAGE,
+    imageUrl: "https://example.com/erika-new-portrait.jpg",
+  };
+  const SUCCESSOR = { ...POLITICIAN_WITH_IMAGE, name: "Erika Musterfrau" };
+
+  let tmpDir;
+  let guidsOf;
+
+  // Every export goes into its own directory under the same basename: the deck name is derived
+  // from the basename (deckNameFor) and is part of the guid, so re-using it is what makes these
+  // two runs the same deck rather than two different ones.
+  const exportRun = async (runName, politicians) => {
+    const runDir = path.join(tmpDir, runName);
+    fs.mkdirSync(runDir);
+    const jsonFilePath = path.join(runDir, "fixture.json");
+    fs.writeFileSync(jsonFilePath, JSON.stringify(politicians));
+    return exportOutputFileToApkg(jsonFilePath);
+  };
+
+  beforeAll(async () => {
+    axiosGetMock.mockResolvedValue({ data: Buffer.from("fake-image-bytes") });
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "apkg-reexport-"));
+
+    const runs = {
+      first: [POLITICIAN_WITH_IMAGE, POLITICIAN_WITHOUT_IMAGE],
+      again: [POLITICIAN_WITH_IMAGE, POLITICIAN_WITHOUT_IMAGE],
+      newImage: [IMAGE_CHANGED, POLITICIAN_WITHOUT_IMAGE],
+      reordered: [POLITICIAN_WITHOUT_IMAGE, POLITICIAN_WITH_IMAGE],
+      successor: [SUCCESSOR, POLITICIAN_WITHOUT_IMAGE],
+    };
+
+    const collected = {};
+    for (const [runName, politicians] of Object.entries(runs)) {
+      const { notes } = await readNotesAndCards(
+        await exportRun(runName, politicians),
+      );
+      collected[runName] = new Set(notes.map((note) => note.guid));
+    }
+    guidsOf = (runName) => collected[runName];
+    // one second of throttling per downloaded image (AnkiDeckBuilder), times five runs
+  }, 60_000);
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("gives unchanged input identical note guids, so a re-import updates instead of duplicating", () => {
+    expect([...guidsOf("again")].sort()).toEqual([...guidsOf("first")].sort());
+  });
+
+  it("does not grow the note count when the same deck is imported twice", () => {
+    const afterReimport = new Set([...guidsOf("first"), ...guidsOf("again")]);
+
+    expect(afterReimport.size).toBe(guidsOf("first").size);
+  });
+
+  it("keeps the guids when only a politician's image changed, so learning progress survives", () => {
+    expect([...guidsOf("newImage")].sort()).toEqual(
+      [...guidsOf("first")].sort(),
+    );
+  });
+
+  it("keeps the guids when the source file is merely reordered", () => {
+    expect([...guidsOf("reordered")].sort()).toEqual(
+      [...guidsOf("first")].sort(),
+    );
+  });
+
+  it("gives a new person on a post a new guid, so it is imported as a new card to learn", () => {
+    const added = [...guidsOf("successor")].filter(
+      (guid) => !guidsOf("first").has(guid),
+    );
+
+    expect(added.length).toBe(1);
+  });
+
+  it("leaves the unchanged politician on the deck alone when someone else is replaced", () => {
+    const kept = [...guidsOf("successor")].filter((guid) =>
+      guidsOf("first").has(guid),
+    );
+
+    expect(kept.length).toBe(1);
   });
 });

--- a/src/politicianNoteTypeSql.js
+++ b/src/politicianNoteTypeSql.js
@@ -46,6 +46,9 @@ export const POLITICIAN_FIELDS = [
   "Profil-Photo",
 ];
 
+// the one field deliberately left out of a note's identity — see `noteGuid` below
+const PROFILE_PHOTO_ORD = POLITICIAN_FIELDS.indexOf("Profil-Photo");
+
 const POLITICIAN_TEMPLATES = [
   {
     name: "Amt zu Person",
@@ -316,6 +319,30 @@ const getId = (db, table, col, ts) => {
   return rowObj[col] ? +rowObj[col] + 1 : ts;
 };
 
+// A note's guid is its identity to Anki, and the only lever we have over what an import does with
+// it. On import, a guid already present in the target collection has its note's fields overwritten
+// in place while its cards — interval, due date, review log — are left untouched; an unseen guid
+// becomes a new note whose cards enter the new queue. There is no third option: the .apkg format
+// cannot say "keep the scheduling but ask me again". So what goes in here decides, per field,
+// whether a change silently rewrites a card the user may not be shown again for months, or is put
+// back in front of them.
+//
+// Hence the deck name plus every field except the photo. A new minister, a party switch or a
+// renamed ministry all change the answer being learned, so they must be re-learned: new guid, new
+// note, asked at once. A swapped profile picture does not, so it updates in place and the user's
+// progress survives. Keeping the deck name in leaves the same politician appearing in two decks
+// (Ministerpräsidenten and their own Landesregierung) as two separate notes, as before.
+//
+// What must *not* go in is anything that moves on its own. The previous `sha1(topDeckId + flds)`
+// did, twice over: `topDeckId` comes out of `Date.now()` in anki-apkg-export's constructor, so
+// every export forked every note and a re-import appended a second copy of the whole deck instead
+// of updating it (#71); and `flds` carries the photo field, which holds `<img src="<array
+// index>.<ext>">` and so changes whenever an unrelated politician is inserted above this one.
+const noteGuid = (deckName, fieldValues) => {
+  const identity = fieldValues.filter((_, ord) => ord !== PROFILE_PHOTO_ORD);
+  return sha1([deckName, ...identity].join(SEPARATOR));
+};
+
 const getNoteId = (db, guid, ts) => {
   const query = `SELECT id from notes WHERE guid = :guid ORDER BY id DESC LIMIT 1`;
   const stmt = db.prepare(query);
@@ -377,11 +404,11 @@ export const makeMultiFieldExporter = (deckName) => {
 // non-empty — mirrors Exporter#addCard's insert logic (see anki-apkg-export/src/exporter.js),
 // generalized from exactly-one-card-per-note to the req-driven multi-card case
 export const addNote = (exporter, fieldValues, { tags = [] } = {}) => {
-  const { db, topDeckId, topModelId } = exporter;
+  const { db, topDeckId, topModelId, deckName } = exporter;
   const now = Date.now();
   const flds = fieldValues.join(SEPARATOR);
   const sfld = fieldValues[0];
-  const guid = sha1(`${topDeckId}${flds}`);
+  const guid = noteGuid(deckName, fieldValues);
   const noteId = getNoteId(db, guid, now);
   const strTags =
     tags.length > 0

--- a/src/politicianNoteTypeSql.js
+++ b/src/politicianNoteTypeSql.js
@@ -405,7 +405,11 @@ export const makeMultiFieldExporter = (deckName) => {
 // generalized from exactly-one-card-per-note to the req-driven multi-card case
 export const addNote = (exporter, fieldValues, { tags = [] } = {}) => {
   const { db, topDeckId, topModelId, deckName } = exporter;
+  // note and card ids are epoch milliseconds, but every `mod` column is epoch *seconds* — Anki
+  // reads them as a TimestampSecs. Passing milliseconds there (as this did, and as
+  // anki-apkg-export still does) dates every note to roughly the year 58500
   const now = Date.now();
+  const nowInSeconds = Math.floor(now / 1000);
   const flds = fieldValues.join(SEPARATOR);
   const sfld = fieldValues[0];
   const guid = noteGuid(deckName, fieldValues);
@@ -422,7 +426,7 @@ export const addNote = (exporter, fieldValues, { tags = [] } = {}) => {
     ":id": noteId,
     ":guid": guid,
     ":mid": topModelId,
-    ":mod": getId(db, "notes", "mod", now),
+    ":mod": getId(db, "notes", "mod", nowInSeconds),
     ":usn": -1,
     ":tags": strTags,
     ":flds": flds,
@@ -447,7 +451,7 @@ export const addNote = (exporter, fieldValues, { tags = [] } = {}) => {
       ":nid": noteId,
       ":did": topDeckId,
       ":ord": ord,
-      ":mod": getId(db, "cards", "mod", now),
+      ":mod": getId(db, "cards", "mod", nowInSeconds),
       ":usn": -1,
       ":type": 0,
       ":queue": 0,

--- a/src/politicianNoteTypeSql.js
+++ b/src/politicianNoteTypeSql.js
@@ -322,10 +322,13 @@ const getId = (db, table, col, ts) => {
 // A note's guid is its identity to Anki, and the only lever we have over what an import does with
 // it. On import, a guid already present in the target collection has its note's fields overwritten
 // in place while its cards — interval, due date, review log — are left untouched; an unseen guid
-// becomes a new note whose cards enter the new queue. There is no third option: the .apkg format
-// cannot say "keep the scheduling but ask me again". So what goes in here decides, per field,
-// whether a change silently rewrites a card the user may not be shown again for months, or is put
-// back in front of them.
+// becomes a new note whose cards enter the new queue. That overwrite is conditional, though: the
+// default import rule is `UpdateCondition::IfNewer`, which writes the incoming fields only when
+// their note's `mod` is strictly greater than the one already in the collection — hence the
+// wall-clock epoch seconds `addNote` puts there, which leave every later export newer than every
+// earlier one. There is no third option: the .apkg format cannot say "keep the scheduling but ask
+// me again". So what goes in here decides, per field, whether a change silently rewrites a card the
+// user may not be shown again for months, or is put back in front of them.
 //
 // Hence the deck name plus every field except the photo. A new minister, a party switch or a
 // renamed ministry all change the answer being learned, so they must be re-learned: new guid, new

--- a/src/politicianNoteTypeSql.spec.js
+++ b/src/politicianNoteTypeSql.spec.js
@@ -12,6 +12,10 @@ const guids = (exporter) =>
   (exporter.db.exec("select guid from notes")[0]?.values ?? []).map(
     ([guid]) => guid,
   );
+const noteMods = (exporter) =>
+  (exporter.db.exec("select mod from notes")[0]?.values ?? []).map(
+    ([mod]) => mod,
+  );
 const guidOf = (deckName, fieldValues) => {
   const exporter = makeMultiFieldExporter(deckName);
   addNote(exporter, fieldValues);
@@ -114,6 +118,17 @@ describe("addNote", () => {
       .map(([id]) => id);
     expect(cardIds.length).toBe(2);
     expect(new Set(cardIds).size).toBe(2);
+  });
+
+  it("writes note mod as epoch seconds, not milliseconds — Anki reads it as a TimestampSecs", () => {
+    const exporter = makeMultiFieldExporter("SomeDeck");
+    const before = Math.floor(Date.now() / 1000);
+
+    addNote(exporter, MERZ);
+
+    // a millisecond value would land three orders of magnitude above this range (year ~58500)
+    expect(noteMods(exporter)[0]).toBeGreaterThanOrEqual(before);
+    expect(noteMods(exporter)[0]).toBeLessThanOrEqual(before + 60);
   });
 
   it("keeps notes independent across multiple addNote calls", () => {

--- a/src/politicianNoteTypeSql.spec.js
+++ b/src/politicianNoteTypeSql.spec.js
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import {
   makeMultiFieldExporter,
   addNote,
@@ -129,6 +130,29 @@ describe("addNote", () => {
     // a millisecond value would land three orders of magnitude above this range (year ~58500)
     expect(noteMods(exporter)[0]).toBeGreaterThanOrEqual(before);
     expect(noteMods(exporter)[0]).toBeLessThanOrEqual(before + 60);
+  });
+
+  // A stable guid alone does not buy an update in place. Anki's default import rule is
+  // `UpdateCondition::IfNewer`, which overwrites the note it already holds only when the incoming
+  // one's `mod` is strictly greater — otherwise the import is logged as a duplicate and nothing is
+  // written. Our half of that condition is that a later export must carry a later `mod`; the other
+  // half is whatever sits in the user's collection, which no test of ours can speak for.
+  it("gives a later export a strictly greater note mod, so an import updates instead of skipping", () => {
+    const buildTime = 1_753_900_000_000;
+    const nowSpy = jest.spyOn(Date, "now");
+
+    nowSpy.mockReturnValue(buildTime);
+    const firstBuild = makeMultiFieldExporter("SomeDeck");
+    addNote(firstBuild, MERZ);
+
+    nowSpy.mockReturnValue(buildTime + 86_400_000); // same deck, rebuilt a day later
+    const secondBuild = makeMultiFieldExporter("SomeDeck");
+    addNote(secondBuild, MERZ);
+
+    nowSpy.mockRestore();
+
+    expect(guids(secondBuild)).toEqual(guids(firstBuild)); // Anki matches the note ...
+    expect(noteMods(secondBuild)[0]).toBeGreaterThan(noteMods(firstBuild)[0]); // ... and sees it as newer
   });
 
   it("keeps notes independent across multiple addNote calls", () => {

--- a/src/politicianNoteTypeSql.spec.js
+++ b/src/politicianNoteTypeSql.spec.js
@@ -8,12 +8,24 @@ import {
 
 const notes = (exporter) =>
   exporter.db.exec("select id, mid, flds from notes")[0]?.values ?? [];
+const guids = (exporter) =>
+  (exporter.db.exec("select guid from notes")[0]?.values ?? []).map(
+    ([guid]) => guid,
+  );
+const guidOf = (deckName, fieldValues) => {
+  const exporter = makeMultiFieldExporter(deckName);
+  addNote(exporter, fieldValues);
+  return guids(exporter)[0];
+};
+
 const cards = (exporter) =>
   exporter.db.exec("select id, nid, ord from cards")[0]?.values ?? [];
 const model = (exporter) => {
   const modelsJson = exporter.db.exec("select models from col")[0].values[0][0];
   return JSON.parse(modelsJson)[POLITICIAN_MODEL_ID];
 };
+
+const MERZ = ["Friedrich Merz", "CDU", "Bundeskanzler", '<img src="0.jpg">'];
 
 describe("makeMultiFieldExporter", () => {
   it("re-keys the note type onto the fixed model id and name, not a fresh per-run one", () => {
@@ -117,5 +129,47 @@ describe("addNote", () => {
 
     expect(notes(exporter).length).toBe(2);
     expect(cards(exporter).length).toBe(3);
+  });
+});
+
+// The guid is what an import matches on: a known guid updates the note's fields and leaves its
+// cards (and therefore the user's scheduling) alone, an unknown one creates a new note whose cards
+// land in the new queue. So these are behavioural assertions about what a re-import does, not
+// assertions about a hash. See #71.
+describe("addNote note identity (guid)", () => {
+  it("is stable across separately built decks, so an unchanged politician re-imports as an update", () => {
+    expect(guidOf("SomeDeck", MERZ)).toBe(guidOf("SomeDeck", MERZ));
+  });
+
+  it("ignores the profile photo, so a new picture updates the note instead of resetting progress", () => {
+    const withOtherPhoto = ["Friedrich Merz", "CDU", "Bundeskanzler", '<img src="7.png">'];
+
+    expect(guidOf("SomeDeck", withOtherPhoto)).toBe(guidOf("SomeDeck", MERZ));
+  });
+
+  it("ignores a missing photo too — gaining or losing an image is not a new fact to learn", () => {
+    const withoutPhoto = ["Friedrich Merz", "CDU", "Bundeskanzler", ""];
+
+    expect(guidOf("SomeDeck", withoutPhoto)).toBe(guidOf("SomeDeck", MERZ));
+  });
+
+  it.each([
+    ["a new person on the post", ["Jane Doe", "CDU", "Bundeskanzler", '<img src="0.jpg">']],
+    ["a party switch", ["Friedrich Merz", "SPD", "Bundeskanzler", '<img src="0.jpg">']],
+    ["a renamed post", ["Friedrich Merz", "CDU", "Bundespräsident", '<img src="0.jpg">']],
+  ])("changes on %s, so the user is asked the card again", (_what, changed) => {
+    expect(guidOf("SomeDeck", changed)).not.toBe(guidOf("SomeDeck", MERZ));
+  });
+
+  it("differs per deck, keeping a politician in two decks as two notes", () => {
+    expect(guidOf("DeckOne", MERZ)).not.toBe(guidOf("DeckTwo", MERZ));
+  });
+
+  it("does not depend on how many notes were added before it", () => {
+    const exporter = makeMultiFieldExporter("SomeDeck");
+    addNote(exporter, ["Jane Doe", "N/A", "Ministerin", ""]);
+    addNote(exporter, MERZ);
+
+    expect(guids(exporter)).toContain(guidOf("SomeDeck", MERZ));
   });
 });


### PR DESCRIPTION
Closes #71 (problem **A**), and documents **B**.

## What changed

The note guid is now the deck name plus every field except the photo:

```js
const noteGuid = (deckName, fieldValues) => {
  const identity = fieldValues.filter((_, ord) => ord !== PROFILE_PHOTO_ORD);
  return sha1([deckName, ...identity].join(SEPARATOR));
};
```

The guid is the only lever an `.apkg` has over what a re-import does. A guid already in the collection updates the note's fields and leaves its cards — interval, due date, review log — untouched; an unseen guid becomes a new note whose cards enter the new queue. There is no third option, so what goes into the hash decides, per field, whether a change silently rewrites a card the user may not be shown for months or is put back in front of them.

| change | guid | what the user gets |
|---|---|---|
| nothing | same | note updated in place, progress preserved |
| photo only | same | new portrait, progress preserved |
| new person on a post | new | new card, asked at once |
| party switch | new | new card, asked at once |
| renamed / re-decorated post | new | new card, asked at once |
| source file merely reordered | same | nothing |

The old `sha1(topDeckId + flds)` was wrong twice over. `topDeckId` comes out of `Date.now()` in anki-apkg-export's constructor, so every export forked every note. And `flds` carries the photo field, which holds `<img src="<array index>.<ext>">` — so it ignored an actually swapped portrait while changing whenever an unrelated politician was inserted above this one.

The second commit fixes `mod` being written in milliseconds where Anki reads seconds; see below.

## Verification

Beyond the specs, exported `output/bundesregierung.json` twice against live Wikimedia and compared the two decks directly:

```
notes run1/run2      : 18 18
guid sets identical  : True
union size (=import) : 18          <- AC 2: does not grow to 36
notes.mod run1       : 1785423718 -> 2026-07-30T15:01:58   <- was year ~58500
```

And against the deck currently committed on `main`, quantifying the one-time migration:

```
overlap             : 0
union after import  : 36           <- the documented one-time duplication
```

All 15 new specs were confirmed to fail against the old implementation before the fix, and 97/97 pass after. No `output/` changes are included, per AGENTS.md.

## Acceptance criteria

- [x] **1.** Same input twice → identical guids. Scoped as agreed to *including* the image: an image-only change must also keep the guid.
- [x] **2.** Re-import does not grow the note count. Simulated as the union of two guid sets, which is exactly what Anki keys on.
- [x] **3.** Scheduling survives — this is what AC 1 buys, and the mechanism is now asserted in the spec comments rather than assumed.
- [x] **4.** A changed note updates rather than duplicating — with the agreed correction that name / party / post changes deliberately *do* create a new note, so the user is actually shown them.
- [x] **5.** Covered in the #55 integration harness (`exportOutputFileToApkg re-export identity`), which runs the real export path end to end.
- [x] **6.** README documents **B** under "Re-importing an updated deck", using your observation that Anki distinguishes the stale card ("fällig am …") from its replacement ("Neu #123") — no search recipe needed.

New AC 3, as agreed: an image-only change updates the existing note, creates no second one, and leaves scheduling intact. New AC 4: a changed name / party / post creates a new note whose cards are new.

## Two judgement calls worth your eyes

**The `mod` fix is in scope, in its own commit.** You didn't explicitly bless this one, so it is separated and reverts cleanly. My reasoning: it works today only by accident, and correcting it *later* would strand every already-imported note a thousandfold in the future, where no sane timestamp could ever look newer and the note would never be updated again. This PR spends a one-time duplication anyway; doing it here spends that migration once rather than twice. Say the word and I'll drop the commit.

It also settles the issue's open question about determinism: `mod` must **not** become deterministic. A changed note re-exporting with an unchanged `mod` is declined by the default *update if newer* mode and logged as a duplicate, which breaks AC 4. A byte-identical `.apkg` (#65) is therefore incompatible with the default import mode — #67's JSON-diff decision should stand.

**The deck id is deliberately left on the clock,** contrary to the "First assessment" in the issue. Anki matches decks by name (`get_deck_by_name` in rslib's apkg deck import) and remaps the ids, so the churn never reaches the collection. Making it deterministic would be tidy but would fix nothing.

## Still open, not touched here

`notes.csum` is `sha1(flds)`; Anki expects the sha1 of the first field with HTML stripped (`rslib/src/notes/mod.rs:207`), so its duplicate detection can't see our notes. One line, inherited from anki-apkg-export, harmless for importing — left out to keep this PR to the ACs. Likewise the index-based media filenames colliding across all 18 decks, which wants its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-importing updated decks now preserves existing notes and review history when politician details or photos change.
  * Reordering entries no longer creates duplicate cards.
  * Substantive changes, such as a new person or successor, create new cards for learning.
  * Re-importing the same deck repeatedly no longer increases duplicates.

* **Documentation**
  * Added guidance for removing departed politicians manually.
  * Documented one-time duplication cleanup for decks exported before mid-2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->